### PR TITLE
Correção do Funcionamento do Menu de Usuário nas Demais Páginas. Resolve #366

### DIFF
--- a/Codigo/Evento/EventoWeb/Views/Evento/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Evento/Index.cshtml
@@ -75,8 +75,6 @@
 </div>
 
 @section Scripts {
-	<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-	<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 	<script src="~/lib/datatable/js/datatables.min.js"></script>
 	<script>
 		$(document).ready(function () {

--- a/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
@@ -114,8 +114,7 @@
         </div>
     </footer>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <!-- Scripts na ordem correta -->
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>


### PR DESCRIPTION
O problema estava ocorrendo porque o Bootstrap 4 estava conflitando com o Bootstrap 5 impostados nas paginas. Os atributos data-bs-toggle são do Bootstrap 5, mas estava carregando Bootstrap 4. Múltiplas versões do jQuery podiam causar conflitos.

Correções realizadas:

1. Remoção de scripts duplicados e conflitantes do Bootstrap no layout principal
- EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml

2. Correção da ordem de carregamento dos scripts para garantir o funcionamento do menu dropdown
- EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml

3. Remoção de carregamento duplicado do jQuery na página de listagem de eventos
- EventoWeb/Views/Evento/Index.cshtml