### PR TITLE
Implementado Service ModeloCertificado closes #372

### DIFF
--- a/Codigo/Evento/Core/Service/IModelocertificadoService.cs
+++ b/Codigo/Evento/Core/Service/IModelocertificadoService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Core.Service
+{
+    public interface IModelocertificadoService
+    {
+        uint Create(Modelocertificado modelocertificado);
+        void Update(Modelocertificado modelocertificado);
+        void Delete(uint id);
+        Modelocertificado Get(uint id);
+        IEnumerable<Modelocertificado> GetAll();
+        IEnumerable<Modelocertificado> GetByEvento(uint idEvento);
+    }
+} 

--- a/Codigo/Evento/Service/ModeloCertificadoService.cs
+++ b/Codigo/Evento/Service/ModeloCertificadoService.cs
@@ -21,6 +21,9 @@ namespace Service
 
         public uint Create(Modelocertificado modelocertificado)
         {
+            if (_context.Modelocertificados.Any(m => m.IdEvento == modelocertificado.IdEvento))
+                throw new Exception("Já existe um modelo de certificado para este evento");
+                
             _context.Modelocertificados.Add(modelocertificado);
             _context.SaveChanges();
             return modelocertificado.Id;
@@ -28,7 +31,11 @@ namespace Service
 
         public void Update(Modelocertificado modelocertificado)
         {
-            _context.Modelocertificados.Update(modelocertificado);
+            var existingModel = _context.Modelocertificados.Find(modelocertificado.Id);
+            if (existingModel == null)
+                throw new Exception("Modelo de certificado não encontrado");
+                
+            _context.Entry(existingModel).CurrentValues.SetValues(modelocertificado);
             _context.SaveChanges();
         }
 
@@ -47,7 +54,7 @@ namespace Service
             return _context.Modelocertificados
                 .Include(m => m.IdEventoNavigation)
                 .AsNoTracking()
-                .FirstOrDefault(m => m.Id == id)!;
+                .FirstOrDefault(m => m.Id == id);
         }
 
         public IEnumerable<Modelocertificado> GetAll()

--- a/Codigo/Evento/Service/ModeloCertificadoService.cs
+++ b/Codigo/Evento/Service/ModeloCertificadoService.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Core;
+using Core.Service;
+using Microsoft.EntityFrameworkCore;
+
+namespace Service
+{
+  
+    public class ModelocertificadoService : IModelocertificadoService
+    {
+        private readonly EventoContext _context;
+
+        public ModelocertificadoService(EventoContext context)
+        {
+            _context = context;
+        }
+
+        public uint Create(Modelocertificado modelocertificado)
+        {
+            _context.Modelocertificados.Add(modelocertificado);
+            _context.SaveChanges();
+            return modelocertificado.Id;
+        }
+
+        public void Update(Modelocertificado modelocertificado)
+        {
+            _context.Modelocertificados.Update(modelocertificado);
+            _context.SaveChanges();
+        }
+
+        public void Delete(uint id)
+        {
+            var entity = _context.Modelocertificados.Find(id);
+            if (entity != null)
+            {
+                _context.Modelocertificados.Remove(entity);
+                _context.SaveChanges();
+            }
+        }
+
+        public Modelocertificado Get(uint id)
+        {
+            return _context.Modelocertificados
+                .Include(m => m.IdEventoNavigation)
+                .AsNoTracking()
+                .FirstOrDefault(m => m.Id == id)!;
+        }
+
+        public IEnumerable<Modelocertificado> GetAll()
+        {
+            return _context.Modelocertificados
+                .Include(m => m.IdEventoNavigation)
+                .AsNoTracking()
+                .ToList();
+        }
+
+        public IEnumerable<Modelocertificado> GetByEvento(uint idEvento)
+        {
+            return _context.Modelocertificados
+                .Include(m => m.IdEventoNavigation)
+                .Where(m => m.IdEvento == idEvento)
+                .AsNoTracking()
+                .ToList();
+        }
+    }
+}

--- a/Codigo/Evento/ServiceTests/InscricaoServiceTests.cs
+++ b/Codigo/Evento/ServiceTests/InscricaoServiceTests.cs
@@ -13,6 +13,7 @@ namespace Service.Tests
     {
         private EventoContext _context;
         private IInscricaoService _inscricaoService;
+        private MockUserManager<UsuarioIdentity> _userManager;
 
         [TestInitialize]
         public void Initialize()
@@ -231,7 +232,11 @@ namespace Service.Tests
             _context.AddRange(inscricoes);
             _context.SaveChanges();
 
-            _inscricaoService = new InscricaoService(_context);
+            _userManager = new MockUserManager<UsuarioIdentity>();
+            _inscricaoService = new InscricaoService(_context, _userManager);
+
+            var user = new UsuarioIdentity { UserName = "test@example.com", Email = "test@example.com" };
+            _userManager.CreateAsync(user, "Test@123");
         }
 
         [TestMethod()]
@@ -272,7 +277,7 @@ namespace Service.Tests
         public void DeleteTest()
         {
             // Act
-            _inscricaoService.DeletePessoaPapel(1, 1, 1);
+            _inscricaoService.DeletePessoaPapel(1, 1, 1, "12246232367");
             // Assert
             var inscricoes = _inscricaoService.GetByEventoAndPapel(1, 1);
             Assert.IsNotNull(inscricoes);

--- a/Codigo/Evento/ServiceTests/MockUserManager.cs
+++ b/Codigo/Evento/ServiceTests/MockUserManager.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventoWeb.Models;
+using Core;
+
+namespace Service.Tests
+{
+    public class MockUserManager<TUser> : UserManager<TUser> where TUser : class
+    {
+         private readonly Dictionary<string, TUser> _users = new Dictionary<string, TUser>();
+
+         public MockUserManager()
+             : base(new Mock<IUserStore<TUser>>().Object,
+                   new Mock<IOptions<IdentityOptions>>().Object,
+                   new Mock<IPasswordHasher<TUser>>().Object,
+                   new IUserValidator<TUser>[0],
+                   new IPasswordValidator<TUser>[0],
+                   new Mock<ILookupNormalizer>().Object,
+                   new Mock<IdentityErrorDescriber>().Object,
+                   new Mock<IServiceProvider>().Object,
+                   new Mock<ILogger<UserManager<TUser>>>().Object)
+         { }
+
+         public override Task<IdentityResult> CreateAsync(TUser user, string password)
+         {
+             if (user is UsuarioIdentity usuario)
+             {
+                 _users[usuario.Id] = user;
+                 _users[usuario.Email] = user;
+             }
+             return Task.FromResult(IdentityResult.Success);
+         }
+
+         public override Task<IdentityResult> AddToRoleAsync(TUser user, string role)
+         {
+             return Task.FromResult(IdentityResult.Success);
+         }
+
+         public override Task<TUser> FindByEmailAsync(string email)
+         {
+             if (_users.TryGetValue(email, out var user))
+             {
+                 return Task.FromResult(user);
+             }
+             return Task.FromResult((TUser)null);
+         }
+
+         public override Task<TUser> FindByIdAsync(string userId)
+         {
+             if (_users.TryGetValue(userId, out var user))
+             {
+                 return Task.FromResult(user);
+             }
+             return Task.FromResult((TUser)null);
+         }
+
+         public override Task<IList<string>> GetRolesAsync(TUser user)
+         {
+             return Task.FromResult<IList<string>>(new List<string> { "Participante" });
+         }
+    }
+} 

--- a/Codigo/Evento/ServiceTests/ModelocertificadoServiceTests.cs
+++ b/Codigo/Evento/ServiceTests/ModelocertificadoServiceTests.cs
@@ -1,0 +1,178 @@
+using Core.Service;
+using Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace Service.Tests
+{
+    [TestClass]
+    public class ModelocertificadoServiceTests
+    {
+        private EventoContext _context;
+        private IModelocertificadoService _modelocertificadoService;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            // Arrange
+            var builder = new DbContextOptionsBuilder<EventoContext>();
+            builder.UseInMemoryDatabase("evento");
+            var options = builder.Options;
+
+            _context = new EventoContext(options);
+            _context.Database.EnsureDeleted();
+            _context.Database.EnsureCreated();
+
+            // Criar eventos para os modelos de certificado
+            var eventos = new List<Evento>
+            {
+                new Evento { Id = 1, Nome = "Evento 1", Status = "A", Descricao = "Descrição do Evento 1", DataInicio = DateTime.Now, DataFim = DateTime.Now.AddDays(1) },
+                new Evento { Id = 2, Nome = "Evento 2", Status = "A", Descricao = "Descrição do Evento 2", DataInicio = DateTime.Now, DataFim = DateTime.Now.AddDays(1) },
+                new Evento { Id = 3, Nome = "Evento 3", Status = "A", Descricao = "Descrição do Evento 3", DataInicio = DateTime.Now, DataFim = DateTime.Now.AddDays(1) }
+            };
+            _context.AddRange(eventos);
+
+            var modelocertificados = new List<Modelocertificado>
+            {
+                new Modelocertificado
+                {
+                    Id = 1,
+                    IdEvento = 1,
+                    LogotipoSuperior = new byte[] { 0x20, 0x20 },
+                    TextoAntesParticipante = "Certificamos que",
+                    TextoAntesEvento = "participou do evento",
+                    TextoAntesCargaHoraria = "com carga horária de",
+                    Assinatura1Texto = "Assinatura 1",
+                    Assinatura1 = new byte[] { 0x21, 0x21 }
+                },
+                new Modelocertificado
+                {
+                    Id = 2,
+                    IdEvento = 2,
+                    LogotipoSuperior = new byte[] { 0x30, 0x30 },
+                    TextoAntesParticipante = "Certificamos que",
+                    TextoAntesEvento = "participou do evento",
+                    TextoAntesCargaHoraria = "com carga horária de",
+                    Assinatura1Texto = "Assinatura 1",
+                    Assinatura1 = new byte[] { 0x31, 0x31 },
+                    Assinatura2Texto = "Assinatura 2",
+                    Assinatura2 = new byte[] { 0x32, 0x32 }
+                },
+                new Modelocertificado
+                {
+                    Id = 3,
+                    IdEvento = 3,
+                    LogotipoSuperior = new byte[] { 0x40, 0x40 },
+                    TextoAntesParticipante = "Certificamos que",
+                    TextoAntesEvento = "participou do evento",
+                    TextoAntesCargaHoraria = "com carga horária de",
+                    Assinatura1Texto = "Assinatura 1",
+                    Assinatura1 = new byte[] { 0x41, 0x41 }
+                }
+            };
+
+            _context.AddRange(modelocertificados);
+            _context.SaveChanges();
+
+            _modelocertificadoService = new ModelocertificadoService(_context);
+        }
+
+        [TestMethod]
+        public void CreateTest()
+        {
+            // Act
+            var novoModelo = new Modelocertificado
+            {
+                Id = 4,
+                IdEvento = 1,
+                LogotipoSuperior = new byte[] { 0x50, 0x50 },
+                TextoAntesParticipante = "Certificamos que",
+                TextoAntesEvento = "participou do evento",
+                TextoAntesCargaHoraria = "com carga horária de",
+                Assinatura1Texto = "Assinatura 1",
+                Assinatura1 = new byte[] { 0x51, 0x51 }
+            };
+
+            _modelocertificadoService.Create(novoModelo);
+
+            // Assert
+            Assert.AreEqual(4, _modelocertificadoService.GetAll().Count());
+            var modelocertificado = _modelocertificadoService.Get(4);
+            Assert.IsNotNull(modelocertificado);
+            Assert.AreEqual((uint)1, modelocertificado.IdEvento);
+            CollectionAssert.AreEqual(new byte[] { 0x50, 0x50 }, modelocertificado.LogotipoSuperior);
+            Assert.AreEqual("Certificamos que", modelocertificado.TextoAntesParticipante);
+        }
+
+        [TestMethod]
+        public void DeleteTest()
+        {
+            // Act
+            _modelocertificadoService.Delete(1);
+
+            // Assert
+            Assert.AreEqual(2, _modelocertificadoService.GetAll().Count());
+            var modelocertificado = _modelocertificadoService.Get(1);
+            Assert.IsNull(modelocertificado);
+        }
+
+        [TestMethod]
+        public void UpdateTest()
+        {
+            // Act 
+            var modelocertificado = _modelocertificadoService.Get(2);
+            _context.Entry(modelocertificado).State = EntityState.Detached;
+            modelocertificado.TextoAntesParticipante = "Certificamos que o participante";
+            modelocertificado.TextoAntesEvento = "participou com sucesso do evento";
+            _modelocertificadoService.Update(modelocertificado);
+
+            // Assert
+            modelocertificado = _modelocertificadoService.Get(2);
+            Assert.AreEqual("Certificamos que o participante", modelocertificado.TextoAntesParticipante);
+            Assert.AreEqual("participou com sucesso do evento", modelocertificado.TextoAntesEvento);
+        }
+
+        [TestMethod]
+        public void GetTest()
+        {
+            var modelocertificado = _modelocertificadoService.Get(2);
+            Assert.IsNotNull(modelocertificado);
+            Assert.AreEqual((uint)2, modelocertificado.IdEvento);
+            Assert.AreEqual("Certificamos que", modelocertificado.TextoAntesParticipante);
+            CollectionAssert.AreEqual(new byte[] { 0x30, 0x30 }, modelocertificado.LogotipoSuperior);
+        }
+
+        [TestMethod]
+        public void GetAllTest()
+        {
+            // Act
+            var listaModelocertificado = _modelocertificadoService.GetAll();
+
+            // Assert
+            Assert.IsInstanceOfType(listaModelocertificado, typeof(IEnumerable<Modelocertificado>));
+            Assert.IsNotNull(listaModelocertificado);
+            Assert.AreEqual(3, listaModelocertificado.Count());
+            var firstModelocertificado = listaModelocertificado.First();
+            Assert.AreEqual((uint)1, firstModelocertificado.IdEvento);
+            Assert.AreEqual("Certificamos que", firstModelocertificado.TextoAntesParticipante);
+        }
+
+        [TestMethod]
+        public void GetByEventoTest()
+        {
+            // Act
+            var modelocertificados = _modelocertificadoService.GetByEvento(1);
+
+            // Assert
+            Assert.IsNotNull(modelocertificados);
+            Assert.AreEqual(1, modelocertificados.Count());
+            var modelocertificado = modelocertificados.First();
+            Assert.AreEqual((uint)1, modelocertificado.IdEvento);
+            Assert.AreEqual("Certificamos que", modelocertificado.TextoAntesParticipante);
+            CollectionAssert.AreEqual(new byte[] { 0x20, 0x20 }, modelocertificado.LogotipoSuperior);
+        }
+    }
+} 

--- a/Codigo/Evento/ServiceTests/PessoaServiceTests.cs
+++ b/Codigo/Evento/ServiceTests/PessoaServiceTests.cs
@@ -6,6 +6,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Immutable;
 using System.Runtime.ConstrainedExecution;
 using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Identity;
+using EventoWeb.Models;
 
 namespace Service.Tests
 {
@@ -15,6 +19,7 @@ namespace Service.Tests
 
         private EventoContext _context;
         private IPessoaService _pessoaService;
+        private MockUserManager<UsuarioIdentity> _userManager;
         private IInscricaoService _inscricaoService;
 
         [TestInitialize]
@@ -130,9 +135,10 @@ namespace Service.Tests
             _context.AddRange(papel);
             _context.SaveChanges();
 
-            _inscricaoService = new InscricaoService(_context);
+            _userManager = new MockUserManager<UsuarioIdentity>();
+            _inscricaoService = new InscricaoService(_context, _userManager);
 
-            _pessoaService = new PessoaService(_context,_inscricaoService);
+            _pessoaService = new PessoaService(_userManager, _context, _inscricaoService);
         }
 
         [TestMethod()]
@@ -270,7 +276,7 @@ namespace Service.Tests
             var pessoa = _pessoaService.Get(1);
 
 
-            _pessoaService.CreatePessoaPapel(pessoa, 1, 1);
+            _pessoaService.CreatePessoaPapelAsync(pessoa, 1, 1);
 
             var inscricao = _context.Inscricaopessoaeventos.FirstOrDefault();
             Assert.IsNotNull(inscricao);

--- a/Codigo/Evento/ServiceTests/ServiceTests.csproj
+++ b/Codigo/Evento/ServiceTests/ServiceTests.csproj
@@ -10,10 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -21,7 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Service\Service.csproj" />
+    <ProjectReference Include="..\EventoWeb\EventoWeb.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Cria classe `ModelocertificadoService` em `Service`  
- Implementa `IModelocertificadoService` com métodos: `Create`, `Update`, `Delete`, `Get`, `GetAll`, `GetByEvento`  
- Utiliza EF Core (`Include`, `AsNoTracking`) para recuperar navegações de evento  