### PR TITLE
Correções Feitas no Botão Cancelar das Views do CRUD Colaborador. Resolve #405

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/ColaboradorController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/ColaboradorController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace EventoWeb.Controllers
 {
+    [Route("[controller]")]
     public class ColaboradorController : Controller
     {
         private readonly IColaboradorService _colaboradorService;
@@ -18,6 +19,9 @@ namespace EventoWeb.Controllers
             _mapper = mapper;
         }
 
+        [HttpGet]
+        [Route("")]
+        [Route("Index")]
         public async Task<ActionResult> Index()
         {
             try
@@ -37,6 +41,8 @@ namespace EventoWeb.Controllers
             }
         }
 
+        [HttpGet]
+        [Route("Create")]
         public async Task<ActionResult> Create()
         {
             try
@@ -51,13 +57,14 @@ namespace EventoWeb.Controllers
             }
             catch (Exception ex)
             {
-                TempData["ErrorMessage"] = $"Erro ao carregar formul·rio: {ex.Message}";
+                TempData["ErrorMessage"] = $"Erro ao carregar formul√°rio: {ex.Message}";
                 System.Diagnostics.Debug.WriteLine($"Erro: {ex.Message}");
                 return RedirectToAction("Index");
             }
         }
 
         [HttpPost]
+        [Route("Create")]
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Create(ColaboradorModel colaboradorModel)
         {
@@ -87,6 +94,8 @@ namespace EventoWeb.Controllers
             return View(colaboradorModel);
         }
 
+        [HttpGet]
+        [Route("Edit/{cpf}")]
         public async Task<ActionResult> Edit(string cpf)
         {
             try
@@ -113,6 +122,7 @@ namespace EventoWeb.Controllers
         }
 
         [HttpPost]
+        [Route("Edit/{cpf}")]
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Edit(string cpf, ColaboradorModel colaboradorModel)
         {
@@ -134,6 +144,8 @@ namespace EventoWeb.Controllers
             return View(colaboradorModel);
         }
 
+        [HttpGet]
+        [Route("Details/{cpf}")]
         public async Task<ActionResult> Details(string cpf)
         {
             try
@@ -159,6 +171,8 @@ namespace EventoWeb.Controllers
             }
         }
 
+        [HttpGet]
+        [Route("Delete/{cpf}")]
         public async Task<ActionResult> Delete(string cpf)
         {
             try
@@ -185,6 +199,7 @@ namespace EventoWeb.Controllers
         }
 
         [HttpPost]
+        [Route("Delete/{cpf}")]
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Delete(string cpf, ColaboradorModel colaboradorModel)
         {

--- a/Codigo/Evento/EventoWeb/Views/Colaborador/Details.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Colaborador/Details.cshtml
@@ -72,7 +72,7 @@
                 </a>
             </div>
             <div class="form-group">
-                <a  asp-controller="Colaborador"asp-Controller="Index" asp-route-cpf="@Model.Colaborador.Cpf" class="btn btn-outline-danger">Cancelar</a>
+                <a asp-action="Index" class="btn btn-outline-secondary">Cancelar</a>
             </div>
         </div>
     </div>

--- a/Codigo/Evento/EventoWeb/Views/Colaborador/Edit.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Colaborador/Edit.cshtml
@@ -161,7 +161,7 @@
                     <input type="submit" value="Salvar" class="btn btn-blue-normal color-white" />
                 </div>
                 <div class="form-group">
-                    <a asp-action="Details" asp-controller="Colaborador" asp-route-cpf="@Model.Colaborador.Cpf" class="btn btn-outline-danger">Cancelar</a>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Cancelar</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As correções nos botões foram feitas, as rotas necessárias no Controller foram adicionadas e os botões agora estão exercendo sua função corretamente.

ColaboradorController.cs:
 -Adicionei rotas para Index, Create, Edit, Details, Delete
(Faltava o atributo [Route("[controller]")] na classe, Faltavam os atributos [Route("")] e [Route("Index")] no método Index, Faltavam os atributos [HttpGet] e [Route("...")] nos outros métodos)

Edit.cshtml:
 -Corrigi sintaxe do botão Cancelar para ele acessar corretamente a rota Index.

Details.cshtml:
 -Corrigi sintaxe do botão Cancelar para ele acessar corretamente a rota Index.

Obs: Relacionado ao problema do botão na View Delete: A Controller não estava seguindo o padrão do .NET Core MVC para configuração de rotas. Quando você acessava /Colaborador, deveria automaticamente redirecionar para /Colaborador/Index, mas estava retornando erro 404. As configurações foram feitas e o problema foi resolvido. Agora /Colaborador pode ser acessado sem problemas.