### PR TITLE
Resolução das Falhas do ParticipanteControllerTests. Resolve #430

### DIFF
--- a/Codigo/Evento/Core/Service/IParticipanteService.cs
+++ b/Codigo/Evento/Core/Service/IParticipanteService.cs
@@ -9,4 +9,6 @@ public interface IParticipanteService
     Task<IEnumerable<PessoaSimpleDTO>> GetParticipantesAsync();
 
     Task DeleteAsync(string cpf);
+
+    Task<Pessoa?> GetParticipanteByCpfAsync(string cpf);
 }

--- a/Codigo/Evento/EventoWeb/Controllers/ParticipanteController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/ParticipanteController.cs
@@ -101,12 +101,13 @@ namespace EventoWeb.Controllers
         [Route("Details/{cpf}")]
         public async Task<ActionResult> Details(string cpf)
         {
-            var participantes = await _participanteService.GetParticipantesAsync();
-            var participante = participantes.FirstOrDefault(c => c.Cpf == cpf);
+         
+            var participante = await _participanteService.GetParticipanteByCpfAsync(cpf);
             if (participante == null)
             {
                 return NotFound();
             }
+            var participantes = await _participanteService.GetParticipantesAsync();
             var participanteModel = new ParticipanteModel
             {
                 Participante = _mapper.Map<PessoaModel>(participante),

--- a/Codigo/Evento/EventoWebTests/Controllers/ParticipanteControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/ParticipanteControllerTests.cs
@@ -34,6 +34,9 @@ namespace EventoWeb.Controllers.Tests
             mockService.Setup(service => service.DeleteAsync(It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
 
+            mockService.Setup(service => service.GetParticipanteByCpfAsync("040.268.930-57"))
+                .ReturnsAsync(GetTargetParticipante());
+
             controller = new ParticipanteController(mockService.Object, mapper);
         }
 

--- a/Codigo/Evento/Service/ParticipanteService.cs
+++ b/Codigo/Evento/Service/ParticipanteService.cs
@@ -104,5 +104,10 @@ public class ParticipanteService : IParticipanteService
         }
     }
 
-
+    public async Task<Pessoa?> GetParticipanteByCpfAsync(string cpf)
+    {
+        // Busca a pessoa completa pelo CPF usando o serviço de pessoas
+        // Pode ser síncrono, mas mantemos async para compatibilidade com a interface
+        return await Task.FromResult(_pessoaService.GetByCpf(cpf));
+    }
 }


### PR DESCRIPTION
O problema ocorreu porque o teste DetailsTest esperava que o campo NomeCracha do participante seja 'Sodré', mas o método Details do ParticipanteController está buscando os participantes usando GetParticipantesAsync(), que retorna PessoaSimpleDTO e não inclui o campo NomeCracha.

Alterações feitas:

-Implementei o método GetParticipanteByCpfAsync em ParticipanteService e ajustei o controller para buscar os dados completos do participante na tela de detalhes.