### PR TITLE
Correção do Erro no Cadastrar Novo Evento. Resolve #450

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
@@ -89,6 +89,7 @@ namespace EventoWeb.Controllers
 		[Authorize(Roles = "ADMINISTRADOR")]
 		// POST: EventoController/Create
 		[HttpPost]
+		[Route("Create")]
 		[ValidateAntiForgeryToken]
 		public ActionResult Create(EventoModel eventoModel)
 		{
@@ -152,6 +153,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/Edit/5
 		[HttpPost]
+		[Route("Edit/{id}")]
 		[ValidateAntiForgeryToken]
 		public ActionResult Edit(uint id, EventoModel viewModel)
 		{
@@ -213,6 +215,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/Delete/5
 		[HttpPost]
+		[Route("Delete/{id}")]
 		[ValidateAntiForgeryToken]
 		public ActionResult Delete(uint id, EventoModel eventoModel)
 		{
@@ -234,6 +237,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/CreateGestor
 		[HttpPost]
+		[Route("CreateGestor")]
 		[ValidateAntiForgeryToken]
 		public ActionResult CreateGestor(GestaoPapelModel gestaoPapelModel)
 		{
@@ -304,6 +308,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/CreateColaborador
 		[HttpPost]
+		[Route("CreateColaborador")]
 		[ValidateAntiForgeryToken]
 		public ActionResult CreateColaborador(GestaoPapelModel gestaoPapelModel)
 		{
@@ -372,6 +377,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/CreateParticipante
 		[HttpPost]
+		[Route("CreateParticipante")]
 		[ValidateAntiForgeryToken]
 		public ActionResult CreateParticipante(GestaoPapelModel gestaoPapelModel)
 		{
@@ -566,6 +572,7 @@ namespace EventoWeb.Controllers
 
 		// POST: EventoController/GestorEditarEvento/5
 		[HttpPost]
+		[Route("GestorEditarEvento/{id}")]
 		[ValidateAntiForgeryToken]
 		[Authorize(Roles = "GESTOR")]
 		public ActionResult GestorEditarEvento(uint id, EventoModel viewModel)

--- a/Codigo/Evento/EventoWeb/Program.cs
+++ b/Codigo/Evento/EventoWeb/Program.cs
@@ -134,13 +134,7 @@ namespace EventoWeb
             app.UseAuthentication();
             app.UseAuthorization();
 
-            // Inicializa os roles do sistema
-            using (var scope = app.Services.CreateScope())
-            {
-                var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-                IdentityInitializer.InitializeRoles(roleManager).Wait();
-            }
-
+            // Middleware personalizado para definir layout baseado no role
             app.Use(async (context, next) =>
             {
                 var isAuthenticated = context.User.Identity.IsAuthenticated;
@@ -161,6 +155,13 @@ namespace EventoWeb
 
                 await next();
             });
+
+            // Inicializa os roles do sistema
+            using (var scope = app.Services.CreateScope())
+            {
+                var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+                IdentityInitializer.InitializeRoles(roleManager).Wait();
+            }
 
             app.MapRazorPages();
 


### PR DESCRIPTION
Um middleware personalizado estava sendo executado na ordem errada. Ele estava sendo executado depois do app.UseAuthorization(), o que estava interferindo com o roteamento. Também encontre alguns métodos POST sem rotas explícitas definidas no EventoController que podem gerar erro ao tentar acessa-los futuramente.

Correções:

1. Movi o middleware personalizado para antes da autorização, para que ele fosse executado na ordem correta. 
 -Program.cs

2. Adicionei rotas explícitas para todos os métodos POST no EventoController. 
 -EventoController.cs