### PR TITLE
Correção do Erro ao Acessar CreateParticipante. Resolve #452

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
@@ -61,8 +61,10 @@ namespace EventoWeb.Controllers
 		}
 
 		[Authorize(Roles = "ADMINISTRADOR")]
-		// GET: EventoController/Details/5
-		public ActionResult Details(uint id)
+        // GET: EventoController/Details/5
+        [HttpGet]
+        [Route("Details/{id}")]
+        public ActionResult Details(uint id)
 		{
 			Evento evento = _eventoService.Get(id);
 			EventoModel eventoModel = _mapper.Map<EventoModel>(evento);
@@ -201,8 +203,10 @@ namespace EventoWeb.Controllers
 		}
 
 		[Authorize(Roles = "ADMINISTRADOR")]
-		// GET: EventoController/Delete/5
-		public ActionResult Delete(uint id)
+        // GET: EventoController/Delete/5
+        [HttpGet]
+        [Route("Delete/{id}")]
+        public ActionResult Delete(uint id)
 		{
 			var evento = _eventoService.Get(id);
 			var eventoModel = _mapper.Map<EventoModel>(evento);
@@ -224,8 +228,10 @@ namespace EventoWeb.Controllers
 		}
 
 		[Authorize(Roles = "ADMINISTRADOR")]
-		// GET: EventoController/CreateGestor
-		public ActionResult CreateGestor(uint idEvento)
+        // GET: EventoController/CreateGestor
+        [HttpGet]
+        [Route("CreateGestor")]
+        public ActionResult CreateGestor(uint idEvento)
 		{
 			var gestorModel = new GestaoPapelModel
 			{
@@ -285,8 +291,10 @@ namespace EventoWeb.Controllers
 
 		
 		[Authorize(Roles = "ADMINISTRADOR,GESTOR,COLABORADOR")]
-		// GET: EventoController/CreateColaborador
-		public ActionResult CreateColaborador(uint idEvento)
+        // GET: EventoController/CreateColaborador
+        [HttpGet]
+        [Route("CreateColaborador")]
+        public ActionResult CreateColaborador(uint idEvento)
 		{
 			
 			var gestor = _inscricaoService.GetGestorInEvent(User.Identity.Name, idEvento);
@@ -355,18 +363,33 @@ namespace EventoWeb.Controllers
 		}
 		
 		[Authorize(Roles = "ADMINISTRADOR,GESTOR,COLABORADOR")]
-		// GET: EventoController/CreateParticipante
-		public ActionResult CreateParticipante(uint idEvento)
-		{
-			var gestor = _inscricaoService.GetGestorInEvent(User.Identity.Name, idEvento);
-			var colaborador = _inscricaoService.GetColaboradorInEvent(User.Identity.Name, idEvento);
+        // GET: EventoController/CreateParticipante
+        [HttpGet]
+        [Route("CreateParticipante")]
+        public ActionResult CreateParticipante(uint idEvento)
+        {
+            // Verifica se o evento existe
+            var evento = _eventoService.Get(idEvento);
+            if (evento == null)
+            {
+                TempData.Clear();
+                TempData["Message"] = "Evento não encontrado!";
+                return RedirectToAction("Index", "Home");
+            }
 
-			if(gestor == null && colaborador == null){
-				TempData.Clear();
-				TempData["Message"] = "Você não tem permissão para criar um participante!";
-				return RedirectToAction("GerenciarEvento");
-			}else{
-			var gestorModel = new GestaoPapelModel
+            var gestor = _inscricaoService.GetGestorInEvent(User.Identity.Name, idEvento);
+            var colaborador = _inscricaoService.GetColaboradorInEvent(User.Identity.Name, idEvento);
+            var isAdmin = User.IsInRole("ADMINISTRADOR");
+
+            if (!isAdmin && gestor == null && colaborador == null)
+            {
+                TempData.Clear();
+                TempData["Message"] = "Você não tem permissão para criar um participante!";
+                return RedirectToAction("GerenciarEvento", new { idEvento });
+            }
+            else
+            {
+                var gestorModel = new GestaoPapelModel
 			{
 				Evento = _eventoService.GetEventoSimpleDto(idEvento),
 				Inscricoes = _inscricaoService.GetByEventoAndPapel(idEvento, 4),
@@ -408,8 +431,10 @@ namespace EventoWeb.Controllers
 			return View(gestaoPapelModel);
 		}
 
-		// POST: EventoController/DeletePessoaPapel
-		public IActionResult DeletePessoaPapel(uint idPessoa, uint idEvento, uint idPapel)
+        // POST: EventoController/DeletePessoaPapel
+        [HttpPost]
+        [Route("DeletePessoaPapel")]
+        public IActionResult DeletePessoaPapel(uint idPessoa, uint idEvento, uint idPapel)
 		{
 			var pessoa = _pessoaService.Get(idPessoa);
 			if (pessoa == null || string.IsNullOrEmpty(pessoa.Cpf))
@@ -512,7 +537,16 @@ namespace EventoWeb.Controllers
 		public IActionResult GerenciarEvento([FromQuery] uint idEvento)
 		{
 			Evento evento = _eventoService.Get(idEvento);
-			var gestor = _inscricaoService.GetGestorInEvent(User.Identity.Name, idEvento);
+
+            // Verifica se o evento existe
+            if (evento == null)
+            {
+                TempData.Clear();
+                TempData["Message"] = "Evento não encontrado!";
+                return RedirectToAction("Index", "Home");
+            }
+
+            var gestor = _inscricaoService.GetGestorInEvent(User.Identity.Name, idEvento);
 			var colaborador = _inscricaoService.GetColaboradorInEvent(User.Identity.Name, idEvento);
 			var isAdmin = User.IsInRole("ADMINISTRADOR");
 
@@ -533,7 +567,9 @@ namespace EventoWeb.Controllers
 		//[Authorize(Roles = "GESTOR, COLABORADOR")]
 		// GET: EventoController/GestorEditarEvento/5
 		[Authorize(Roles = "GESTOR")]
-		public ActionResult GestorEditarEvento(uint id)
+        [HttpGet]
+        [Route("GestorEditarEvento/{id}")]
+        public ActionResult GestorEditarEvento(uint id)
 		{
 			var evento = _eventoService.Get(id);
 			

--- a/Codigo/Evento/EventoWeb/Mappers/EventoProfile.cs
+++ b/Codigo/Evento/EventoWeb/Mappers/EventoProfile.cs
@@ -12,14 +12,24 @@ public class EventoProfile : Profile
 		.ForMember(dest => dest.IdAreaInteresses, opt => opt.Ignore())
 		.ForMember(dest => dest.ImagemPortal, opt => opt.MapFrom(src => src.ImagemPortal != null ? FormFileToByteArray(src.ImagemPortal) : null))
 		.ReverseMap()
-		.ForMember(dest => dest.ImagemPortal, opt => opt.MapFrom(src => ByteArrayToFormFile(src.ImagemPortal, "ImagemPortal.png")))
-		.ForMember(dest => dest.ImagemPortalBase64, opt => opt.MapFrom(src => Convert.ToBase64String(src.ImagemPortal)));
+        .ForMember(dest => dest.ImagemPortal, opt => opt.Ignore())
+        .ForMember(dest => dest.ImagemPortalBase64, opt => opt.MapFrom(src => src.ImagemPortal != null ? Convert.ToBase64String(src.ImagemPortal) : string.Empty));
 
-	}
+    }
 
 	private static IFormFile ByteArrayToFormFile(byte[] byteArray, string fileName)
-	{
-		var stream = new MemoryStream(byteArray);
+    {
+        if (byteArray == null || byteArray.Length == 0)
+        {
+            var emptyStream = new MemoryStream();
+            return new FormFile(emptyStream, 0, 0, null, fileName)
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = "application/octet-stream"
+            };
+        }
+
+        var stream = new MemoryStream(byteArray);
 		return new FormFile(stream, 0, byteArray.Length, null, fileName)
 		{
 			Headers = new HeaderDictionary(),

--- a/Codigo/Evento/Service/EventoService.cs
+++ b/Codigo/Evento/Service/EventoService.cs
@@ -87,7 +87,7 @@ namespace Service
         /// <exception cref="NotImplementedException"></exception>
         public Evento Get(uint id)
         {
-            return _context.Eventos.Find(id);
+            return _context.Eventos.FirstOrDefault(e => e.Id == id);
         }
         public EventoSimpleDTO GetEventoSimpleDto(uint id)
         {


### PR DESCRIPTION
Ao acessar https://localhost:7281/Evento/CreateParticipante?idEvento=3 (ou qualquer id de Evento) após clicar no card "Participantes" do Dashboard do Gestor (view GerenciarEvento), o sistema retornava erro HTTP 405 e posteriormente NullReferenceException na view GerenciarEvento.

Correções:

1. Adicionei [Route("CreateParticipante")] para o métodos GET do CreateParticipante. 
 -EventoController.cs

2. Adicionei verificação de existência do evento antes de prosseguir com a operação. 
 -EventoController.cs

3. Implementei verificação de role de administrador que estava faltando na validação de permissões. 
 -EventoController.cs

4. Adicionei rotas explícitas para todos os métodos GET no EventoController. 
 -EventoController.cs

5. Alterei método Get no EventoService para usar FirstOrDefault em vez de Find para maior segurança. 
 -EventoService.cs

6. Corrigi mapeamento AutoMapper para lidar com valores null no campo ImagemPortal. 
 -EventoProfile.cs