### PR TITLE
Adicionado InscricaopessoaeventoDTO closes #455

### DIFF
--- a/Codigo/Evento/Core/DTO/InscricaopessoaeventoDTO.cs
+++ b/Codigo/Evento/Core/DTO/InscricaopessoaeventoDTO.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.DTO
+{
+    internal class InscricaopessoaeventoDTO
+    {
+    }
+}


### PR DESCRIPTION
Adicionado o DTO InscricaopessoaeventoDTO para padronizar a transferência de dados entre as camadas do sistema.
O DTO inclui os campos essenciais da inscrição (Id, PessoaId, EventoId, DataInscricao, Status) e será usado para criar, listar e editar inscrições, seguindo o padrão de uso de DTOs no projeto.