### PR TITLE
Adicionado InscricaopessoaeventoService closes #457

### DIFF
--- a/Codigo/Evento/Core/Service/IInscricaopessoaeventoService.cs
+++ b/Codigo/Evento/Core/Service/IInscricaopessoaeventoService.cs
@@ -1,21 +1,17 @@
-﻿using System;
+﻿using Core;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Core;
-
 
 namespace Core.Service
 {
     public interface IInscricaopessoaeventoService
     {
         void Create(Inscricaopessoaevento inscricao);
-        Inscricaopessoaevento GetById(int id);
+        Inscricaopessoaevento GetById(uint id);
         IEnumerable<Inscricaopessoaevento> GetAll();
         void Update(Inscricaopessoaevento inscricao);
-        void Delete(int id);
-        //Verifica se a pessoa já está inscrita no evento
-        bool PessoaJaInscrita(int pessoaId, int eventoId);
+        void Delete(uint id);
+
+        // Verifica se uma pessoa já está inscrita em um evento
+        bool PessoaJaInscrita(uint idPessoa, uint idEvento);
     }
 }

--- a/Codigo/Evento/Service/InscricaopessoaeventoService.cs
+++ b/Codigo/Evento/Service/InscricaopessoaeventoService.cs
@@ -1,0 +1,59 @@
+﻿using Core; // Para acessar EventoContext e entidades
+using Core.Service; // Para acessar a interface
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Service
+{
+    public class InscricaopessoaeventoService : IInscricaopessoaeventoService
+    {
+        private readonly EventoContext _context;
+
+        public InscricaopessoaeventoService(EventoContext context)
+        {
+            _context = context;
+        }
+
+        public void Create(Inscricaopessoaevento inscricao)
+        {
+            // Evitar inscrição duplicada para a mesma pessoa e evento
+            if (PessoaJaInscrita(inscricao.IdPessoa, inscricao.IdEvento))
+                throw new System.Exception("Esta pessoa já está inscrita neste evento.");
+
+            inscricao.DataInscricao = System.DateTime.Now;
+            _context.Inscricaopessoaeventos.Add(inscricao); // <- Usando DbSet no plural!
+            _context.SaveChanges();
+        }
+
+        public Inscricaopessoaevento GetById(uint id)
+        {
+            return _context.Inscricaopessoaeventos.Find(id);
+        }
+
+        public IEnumerable<Inscricaopessoaevento> GetAll()
+        {
+            return _context.Inscricaopessoaeventos.ToList();
+        }
+
+        public void Update(Inscricaopessoaevento inscricao)
+        {
+            _context.Inscricaopessoaeventos.Update(inscricao);
+            _context.SaveChanges();
+        }
+
+        public void Delete(uint id)
+        {
+            var inscricao = GetById(id);
+            if (inscricao != null)
+            {
+                _context.Inscricaopessoaeventos.Remove(inscricao);
+                _context.SaveChanges();
+            }
+        }
+
+        public bool PessoaJaInscrita(uint idPessoa, uint idEvento)
+        {
+            return _context.Inscricaopessoaeventos.Any(i => i.IdPessoa == idPessoa && i.IdEvento == idEvento);
+        }
+    }
+}


### PR DESCRIPTION
Implementação completa do serviço InscricaopessoaeventoService, usando o DbSet Inscricaopessoaeventos e os campos corretos (IdPessoa, IdEvento) conforme o modelo do banco de dados.

Ajustado também o arquivo da interface IInscricaopessoaeventoService para garantir compatibilidade com a implementação e padrões do projeto.

Incluída validação para evitar inscrições duplicadas (mesma pessoa no mesmo evento).

Mantido padrão de organização, boas práticas e integração com o Entity Framework.
