### PR TITLE
Correção do Acesso ao Gestores Sistema no Menu Lateral. Resolve #478

### DIFF
--- a/Codigo/Evento/EventoWeb/Mappers/PessoaProfile.cs
+++ b/Codigo/Evento/EventoWeb/Mappers/PessoaProfile.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Core;
 using Core.DTO;
 using EventoWeb.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace EventoWeb.Mappers;
 
@@ -10,11 +11,6 @@ public class PessoaProfile : Profile
     public PessoaProfile()
     {
         CreateMap<PessoaModel, Pessoa>()
-            /*.ForMember(dest => dest.Foto, opt => opt.MapFrom(src => src.Foto != null ? FormFileToByteArray(src.Foto) : null))
-            .ReverseMap()
-            .ForMember(dest => dest.Foto, opt => opt.MapFrom(src => ByteArrayToFormFile(src.Foto, "foto.png")))
-            .ForMember(dest => dest.FotoBase64, opt => opt.MapFrom(src => src.Foto != null ? Convert.ToBase64String(src.Foto) : null));
-            */
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
             .ForMember(dest => dest.Nome, opt => opt.MapFrom(src => src.Nome))
             .ForMember(dest => dest.NomeCracha, opt => opt.MapFrom(src => src.NomeCracha))
@@ -23,33 +19,37 @@ public class PessoaProfile : Profile
             .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
             .ForMember(dest => dest.Telefone1, opt => opt.MapFrom(src => src.Telefone1))
             .ForMember(dest => dest.Telefone2, opt => opt.MapFrom(src => src.Telefone2))
-            .ForMember(dest => dest.Foto, opt => opt.MapFrom(src => src.Foto != null ? FormFileToByteArray(src.Foto) : null))
-            .ReverseMap()
-            .ForMember(dest => dest.Foto, opt => opt.MapFrom(src => ByteArrayToFormFile(src.Foto, "foto.png")))
-            .ForMember(dest => dest.FotoBase64, opt => opt.MapFrom(src => src.Foto != null ? Convert.ToBase64String(src.Foto) : null))
-            .ForMember(dest => dest.Cep, opt => opt.MapFrom(src => src.Cep)) // Ensure this line exists
-            .ForMember(dest => dest.Estado, opt => opt.MapFrom(src => src.Estado)) // Ensure this line exists
-            .ForMember(dest => dest.Cidade, opt => opt.MapFrom(src => src.Cidade)) // Ensure this line exists
-            .ForMember(dest => dest.Bairro, opt => opt.MapFrom(src => src.Bairro)) // Ensure this line exists
-            .ForMember(dest => dest.Rua, opt => opt.MapFrom(src => src.Rua)) // Ensure this line exists
-            .ForMember(dest => dest.Numero, opt => opt.MapFrom(src => src.Numero)) // Ensure this line exists
-            .ForMember(dest => dest.Complemento, opt => opt.MapFrom(src => src.Complemento)); // Ensure this line exists
-        
-        CreateMap<Pessoa, PessoaModel>(); // Also create the reverse map
-        CreateMap<Pessoa, ParticipanteDTO>(); // Based on ParticipanteService.cs, Pessoa needs to be mapped to ParticipanteDTO
+            .ForMember(dest => dest.Cep, opt => opt.MapFrom(src => src.Cep))
+            .ForMember(dest => dest.Estado, opt => opt.MapFrom(src => src.Estado))
+            .ForMember(dest => dest.Cidade, opt => opt.MapFrom(src => src.Cidade))
+            .ForMember(dest => dest.Bairro, opt => opt.MapFrom(src => src.Bairro))
+            .ForMember(dest => dest.Rua, opt => opt.MapFrom(src => src.Rua))
+            .ForMember(dest => dest.Numero, opt => opt.MapFrom(src => src.Numero))
+            .ForMember(dest => dest.Complemento, opt => opt.MapFrom(src => src.Complemento))
+            .ForMember(dest => dest.Foto, opt => opt.MapFrom(src => src.Foto != null ? FormFileToByteArray(src.Foto) : null));
+
+        CreateMap<Pessoa, PessoaModel>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Nome, opt => opt.MapFrom(src => src.Nome))
+            .ForMember(dest => dest.NomeCracha, opt => opt.MapFrom(src => src.NomeCracha))
+            .ForMember(dest => dest.Cpf, opt => opt.MapFrom(src => src.Cpf))
+            .ForMember(dest => dest.Sexo, opt => opt.MapFrom(src => src.Sexo))
+            .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
+            .ForMember(dest => dest.Telefone1, opt => opt.MapFrom(src => src.Telefone1))
+            .ForMember(dest => dest.Telefone2, opt => opt.MapFrom(src => src.Telefone2))
+            .ForMember(dest => dest.Cep, opt => opt.MapFrom(src => src.Cep))
+            .ForMember(dest => dest.Estado, opt => opt.MapFrom(src => src.Estado))
+            .ForMember(dest => dest.Cidade, opt => opt.MapFrom(src => src.Cidade))
+            .ForMember(dest => dest.Bairro, opt => opt.MapFrom(src => src.Bairro))
+            .ForMember(dest => dest.Rua, opt => opt.MapFrom(src => src.Rua))
+            .ForMember(dest => dest.Numero, opt => opt.MapFrom(src => src.Numero))
+            .ForMember(dest => dest.Complemento, opt => opt.MapFrom(src => src.Complemento))
+            .ForMember(dest => dest.Foto, opt => opt.Ignore()) // Ignorar a propriedade Foto no mapeamento reverso
+            .ForMember(dest => dest.FotoBase64, opt => opt.MapFrom(src => src.Foto != null ? Convert.ToBase64String(src.Foto) : null));
+
+        CreateMap<Pessoa, ParticipanteDTO>();
         CreateMap<PessoaSimpleDTO, ParticipanteDTO>();
         CreateMap<PessoaSimpleDTO, PessoaModel>();
-    }
-
-    private static IFormFile ByteArrayToFormFile(byte[] byteArray, string fileName)
-    {
-        if (byteArray == null) return null;
-        var stream = new MemoryStream(byteArray);
-        return new FormFile(stream, 0, byteArray.Length, null, fileName)
-        {
-            Headers = new HeaderDictionary(),
-            ContentType = "application/octet-stream"
-        };
     }
 
     private static byte[] FormFileToByteArray(IFormFile formFile)

--- a/Codigo/Evento/EventoWeb/Program.cs
+++ b/Codigo/Evento/EventoWeb/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Core.DTO;
 using EventoWeb.Models;
+using EventoWeb.Mappers;
 
 namespace EventoWeb
 {
@@ -25,7 +26,7 @@ namespace EventoWeb
 
             builder.Services.AddAutoMapper(cfg =>
             {
-                cfg.CreateMap<PessoaModel, Pessoa>().ReverseMap();
+                cfg.AddProfile<PessoaProfile>();
                 cfg.CreateMap<PessoaSimpleDTO, ColaboradorDTO>()
                     .ForMember(dest => dest.Id, opt => opt.MapFrom(src => 0)) // Valor padrão
                     .ForMember(dest => dest.Cpf, opt => opt.MapFrom(src => src.Cpf))


### PR DESCRIPTION
O erro está relacionado ao AutoMapper tentando mapear um byte[] para IFormFile na propriedade Foto do modelo PessoaModel. O problema é que o PessoaProfile (que deveria conter os mapeamentos específicos para a propriedade Foto) não estava sendo registrado no AutoMapper no Program.cs. E além disso, no PessoaProfile, o mapeamento estava duplicado e havia um conflito.

Correções:

1. Adicionei registro do PessoaProfile no AutoMapper para corrigir mapeamento de propriedades. 
   -Program.cs

2. Corrigi mapeamento duplicado e configurado propriedade Foto para ignorar no mapeamento reverso. 
   -PessoaProfile.cs