### PR TITLE
Ajuste no redirecionamento de modelo crachá.

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/ModelocrachaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/ModelocrachaController.cs
@@ -31,6 +31,7 @@ namespace EventoWeb.Controllers
         [HttpGet]
         [Route("")]
         [Route("Index")]
+
         public ActionResult Index(uint? idEvento, uint? idPessoa)
         {
             if (idEvento.HasValue)
@@ -54,7 +55,9 @@ namespace EventoWeb.Controllers
             }
             else
             {
-                return RedirectToAction("Index", "Evento");
+                var items = _modelocrachaService.GetAll();
+                var model = items.Select(x => _mapper.Map<ModelocrachaModel>(x)).ToList();
+                return View(model);
             }
 
         }


### PR DESCRIPTION
Agora modelo crachá está redirecionando para a tela de listar os modelos crachás existentes, está listando de todos eventos que possuem, independente de o evento ser ou não gerenciado por aquele gestor.