### PR TITLE
Refatorando o processo de exclusão

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -224,8 +224,13 @@ namespace EventoWeb.Controllers
                     TempData["ErrorMessage"] = "Erro ao excluir pessoa";
                 }
 
+            if (User.IsInRole("ADMINISTRADOR"))
+            {
+                return RedirectToAction("DefinirAdministrador", "Pessoa");
+            }
 
-            return View(viewModel);
+
+            return RedirectToAction("Index", "Pessoa");
         }
 
         // =====================================================================

--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -110,7 +110,7 @@ namespace EventoWeb.Controllers
 
                 try
                 {
-                    // Cria Pessoa + Identity + role USUARIO (papel 4)
+                    
                     await _pessoaService.CreatePessoaIdentityComPapelAsync(pessoa, 4);
                     if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
                     {
@@ -267,7 +267,7 @@ namespace EventoWeb.Controllers
                     Email = viewModel.Email
                 };
 
-                // Cria Pessoa + Identity + role ADMINISTRADOR (papel 1)
+               
                 await _pessoaService.CreatePessoaIdentityComPapelAsync(pessoa, 1);
                 TempData["SuccessMessage"] = "Administrador definido com sucesso.";
                 return RedirectToAction(nameof(DefinirAdministrador));

--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -197,12 +197,12 @@ namespace EventoWeb.Controllers
         [HttpGet]
         [Route("Delete/{id}")]
         [Route("Delete")]
-        public ActionResult Delete(PessoaModel viewModel,string? returnUrl)
+        public ActionResult Delete(PessoaModel viewModel)
         {
             var pessoa = _pessoaService.Get(viewModel.Id);
             if (pessoa == null) return NotFound();
             PessoaModel pessoaModel = _mapper.Map<PessoaModel>(pessoa);
-            ViewBag.ReturnUrl = returnUrl;
+            
             return View(pessoaModel);
         }
 
@@ -210,7 +210,7 @@ namespace EventoWeb.Controllers
         [HttpPost, ActionName("Delete")]
         [Route("Delete/{id}")]
         [ValidateAntiForgeryToken]
-        public ActionResult DeleteConfirmed(PessoaModel viewModel,string? returnUrl)
+        public ActionResult DeleteConfirmed(PessoaModel viewModel)
         {
                        
                 var sucesso = _pessoaService.Delete(viewModel.Id);
@@ -224,11 +224,6 @@ namespace EventoWeb.Controllers
                     TempData["ErrorMessage"] = "Erro ao excluir pessoa";
                 }
 
-            
-           if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
-            {
-                return Redirect(returnUrl);
-            }
 
             return View(viewModel);
         }

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -7,136 +7,53 @@
 
 <h1 class="blue-normal">Cadastrar Administradores do Sistema</h1>
 <br />
+
 <div class="row">
-    <div> 
-        <form asp-action="DefinirAdministrador" method="post">
+	<div>
+		<form asp-action="DefinirAdministrador" method="post">
 			<div class="row">
-             <br/>
-			<div class="row">
-				<div class="col-6 col-sm-6 col-md-6 col-lg-6">
-					<div class="form-group mb-4">
-						<label asp-for="Cpf" class="control-label">CPF</label>
-						<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCPF()" maxlength="14" />
-						<span asp-validation-for="Cpf" class="text-danger"></span>
+				<br />
+				<div class="row">
+					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
+						<div class="form-group mb-4">
+							<label asp-for="Cpf" class="control-label">CPF</label>
+							<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCPF()" maxlength="14" />
+							<span asp-validation-for="Cpf" class="text-danger"></span>
+						</div>
+					</div>
+					<div class="col-12 col-sm-6 col-md-6 col-lg-6">
+						<div class="form-group mb-4">
+							<label asp-for="Nome" class="control-label">Nome</label>
+							<input asp-for="Nome" class="form-control" id="Nome" placeholder="Nome completo" />
+							<span asp-validation-for="Nome" class="text-danger"></span>
+						</div>
+					</div>
+					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
+						<div class="form-group mb-4">
+							<label asp-for="Telefone1" class="control-label">Telefone</label>
+							<input asp-for="Telefone1" type="number" class="form-control" id="Telefone1" placeholder="Com o DDD" />
+							<span asp-validation-for="Telefone1" class="text-danger"></span>
+						</div>
+					</div>
+					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
+						<div class="form-group mb-4">
+							<label asp-for="Email" class="control-label">Email</label>
+							<input asp-for="Email" class="form-control" id="Email" placeholder="Seu e-mail" />
+							<span asp-validation-for="Email" class="text-danger"></span>
+						</div>
+					</div>
+					<div class="row">
+						<div class="d-flex flex-row-reverse mb-4">
+							<button type="submit" class="btn btn-lg btn-blue-normal">Adicionar Administrador</button>
+						</div>
 					</div>
 				</div>
-				<div class="col-12 col-sm-6 col-md-6 col-lg-6">
-                        <div class="form-group mb-4">
-						<label asp-for="Nome" class="control-label">Nome</label>
-						<input asp-for="Nome" class="form-control" id="Nome" placeholder="Nome completo" />
-						<span asp-validation-for="Nome" class="text-danger"></span>
-					</div>
-				</div>
-				<div class="col-6 col-sm-6 col-md-6 col-lg-6">
-                        <div class="form-group mb-4">
-						<label asp-for="Telefone1" class="control-label">Telefone</label>
-						<input asp-for="Telefone1" type="number" class="form-control" id="Telefone1" placeholder="Com o DDD" />
-						<span asp-validation-for="Telefone1" class="text-danger"></span>
-					</div>
-				</div>
-				<div class="col-6 col-sm-6 col-md-6 col-lg-6">
-                        <div class="form-group mb-4">
-						<label asp-for="Email" class="control-label">Email</label>
-						<input asp-for="Email" class="form-control" id="Email" placeholder="Seu e-mail" />
-						<span asp-validation-for="Email" class="text-danger"></span>
-					</div>
-				</div>
-                <div class="row">
-                    <div class="d-flex flex-row-reverse mb-4">
-                            <button type="submit" class="btn btn-lg btn-blue-normal">Adicionar Administrador</button>
-                    </div>
-                </div>
-            </div>
-            <br/>
-        </form>
-        
-    </div>
-</div>
-   
-<div class="row">
-    <div class="col-md-12">
-        <table class="table table-striped">
-            <thead class="blue-normal blue-normal-bg-table">
-                <tr>
-                    <th>CPF</th>
-                    <th>Nome</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var item in Model.Administradores)
-                {
-                    <tr>
-                        <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
-                        <td style="vertical-align: middle;">@item.Nome</td>
-                        <td>
-                            <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
-                            @Html.ActionLink("Excluir", "Delete", new { id = item.Id, returnUrl = Url.Action("DefinirAdministrador", "Pessoa") }, new { @class = "btn btn-sm btn-link" })
-                            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha" data-bs-id="@item.Id">Mudar Senha</button>
+				<br />
 
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    </div>
-</div>
-<div class="modal fade" id="modalExcluir" tabindex="-1" role="dialog" aria-labelledby="modalExcluirPessoa" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header bg-primary text-white">
-                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
-                </button>
-            </div>
-              <div class="modal-body text-center">
-                <h4>Tem certeza que deseja excluir?</h4>
-                <span class="text-danger fw-bold small">
-                    ESTA OPERAÇÃO NÃO PODE SER DESFEITA.
-                </span>
-                    <input type="hidden" asp-for="Id" /> 
-                </div>
-                <div class="modal-footer justify-content-center">
-                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-danger" id="btnConfirmarExclusao">Ok</button>
-             </div>
-        </div>
-    </div>
+			</div>
+		</form>
+
+	</div>
 </div>
 
-<div class="modal fade" id="modalMudarSenha" tabindex="-1" role="dialog" aria-labelledby="modalMudarSenhaPessoa" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header bg-primary text-white">
-                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
-                </button>
-            </div>
-            <div class="modal-body text-center">
-                <h4>Tem certeza que deseja mudar a senha?</h4>
-                <span class="text-black-50 fw-bold small">
-                    O administrador vai receber um e-mail para redefinir a senha.
-                </span>
-                <input type="hidden" asp-for="Id" />
-            </div>
-            <div class="modal-footer justify-content-center">
-                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
-                <button type="submit" class="btn btn-danger" id="btnConfirmarMudanca">Sim</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-
-
-@functions {
-
-    public static string FormatarCPF(string cpf)
-    {
-        if (string.IsNullOrEmpty(cpf) || cpf.Length != 11)
-            return cpf;
-
-        return Convert.ToUInt64(cpf).ToString(@"000\.000\.000\-00");
-    }
-
-}
+<partial name="Index" model="Model.Administradores" />

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -42,8 +42,8 @@
 					</div>
 				</div>
                 <div class="row">
-                    <div class="d-flex flex-row-reverse">
-                        <input type="submit" value="Adicionar Administrador" class="btn btn-lg btn-blue-normal"></input>
+                    <div class="d-flex flex-row-reverse mb-4">
+                            <button type="submit" class="btn btn-lg btn-blue-normal">Adicionar Administrador</button>
                     </div>
                 </div>
             </div>
@@ -55,7 +55,6 @@
    
 <div class="row">
     <div class="col-md-12">
-        <h2 class="blue-normal">Lista de Gestores do Evento</h2>
         <table class="table table-striped">
             <thead class="blue-normal blue-normal-bg-table">
                 <tr>
@@ -71,12 +70,10 @@
                         <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
                         <td style="vertical-align: middle;">@item.Nome</td>
                         <td>
-                            @Html.ActionLink("Editar", "Edit", new { id = item.Id, returnUrl = Url.Action("DefinirAdministrador", "Pessoa") }, new { @class = "btn btn-sm btn-link" })
-                            &nbsp;
-                            @Html.ActionLink("Detalhes", "Details", new { id = item.Id, returnUrl = Url.Action("DefinirAdministrador", "Pessoa") }, new { @class = "btn btn-sm btn-link" })
-                            &nbsp;
+                            <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
                             @Html.ActionLink("Excluir", "Delete", new { id = item.Id, returnUrl = Url.Action("DefinirAdministrador", "Pessoa") }, new { @class = "btn btn-sm btn-link" })
-                        
+                            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha" data-bs-id="@item.Id">Mudar Senha</button>
+
                         </td>
                     </tr>
                 }
@@ -84,8 +81,56 @@
         </table>
     </div>
 </div>
+<div class="modal fade" id="modalExcluir" tabindex="-1" role="dialog" aria-labelledby="modalExcluirPessoa" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
+                </button>
+            </div>
+              <div class="modal-body text-center">
+                <h4>Tem certeza que deseja excluir?</h4>
+                <span class="text-danger fw-bold small">
+                    ESTA OPERAÇÃO NÃO PODE SER DESFEITA.
+                </span>
+                    <input type="hidden" asp-for="Id" /> 
+                </div>
+                <div class="modal-footer justify-content-center">
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-danger" id="btnConfirmarExclusao">Ok</button>
+             </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="modalMudarSenha" tabindex="-1" role="dialog" aria-labelledby="modalMudarSenhaPessoa" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
+                </button>
+            </div>
+            <div class="modal-body text-center">
+                <h4>Tem certeza que deseja mudar a senha?</h4>
+                <span class="text-black-50 fw-bold small">
+                    O administrador vai receber um e-mail para redefinir a senha.
+                </span>
+                <input type="hidden" asp-for="Id" />
+            </div>
+            <div class="modal-footer justify-content-center">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="submit" class="btn btn-danger" id="btnConfirmarMudanca">Sim</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
 
 @functions {
+
     public static string FormatarCPF(string cpf)
     {
         if (string.IsNullOrEmpty(cpf) || cpf.Length != 11)
@@ -93,4 +138,5 @@
 
         return Convert.ToUInt64(cpf).ToString(@"000\.000\.000\-00");
     }
+
 }

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Delete.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Delete.cshtml
@@ -131,26 +131,5 @@
         
 </div>
 </div>
-<div class="modal fade" id="modalExcluir" tabindex="-1" role="dialog" aria-labelledby="modalExcluirPessoa" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header bg-primary text-white">
-                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
-                   
-                </button>
-            </div>
-            <form asp-action="Delete">
-                <div class="modal-body text-center">
-                    <h4>Tem certeza que deseja excluir essa pessoa?</h4>
-                    <input type="hidden" asp-for="Id" /> <input type="hidden" name="returnUrl" value="@ViewBag.ReturnUrl" />
-                </div>
-                <div class="modal-footer justify-content-center">
-                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-danger">Excluir</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
+
 

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -1,0 +1,68 @@
+@model EventoWeb.Models.GestorModel
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<link href="~/lib/datatable/css/datatables.min.css" rel="stylesheet" />
+
+<div>
+    <h1 class="blue-normal">Seja Bem-vindo</h1>
+    <table id="tableGestor" class="table table-striped">
+        <thead class="blue-normal blue-normal-bg-table">
+            <tr>
+            <tr>
+                <th>CPF</th>
+                <th>Nome</th>
+                <th>Ações</th>
+            </tr>
+        </thead>
+        <tbody>
+        <tbody>
+            @foreach (var item in Model.Gestores)
+            {
+                <tr>
+                    <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
+                    <td style="vertical-align: middle;">@item.Nome</td>      
+                    <td>
+                       
+                        @Html.ActionLink("Excluir", "Delete", new { id = item.Id, returnUrl = Url.Action("Pessoa") }, new { @class = "btn btn-sm btn-link" })
+                        &nbsp;&nbsp;
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+
+</div>
+@functions {
+    public static string FormatarCPF(string cpf)
+    {
+        if (string.IsNullOrEmpty(cpf) || cpf.Length != 11)
+            return cpf;
+
+        return Convert.ToUInt64(cpf).ToString(@"000\.000\.000\-00");
+    }
+}
+
+@section Scripts {
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/lib/datatable/js/datatables.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $('#tableGestor').DataTable({
+                columnDefs: [
+                    { orderable: true, targets: [0] },
+                    { orderable: false, targets: [1, 2, 3, 4] }
+                ],
+                searching: true,
+                ordering: true,
+                paging: true,
+                language: {
+                    url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
+                }
+            });
+        });
+    </script>
+}

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -1,41 +1,87 @@
-@model EventoWeb.Models.GestorModel
+@model  IEnumerable<EventoWeb.Models.PessoaModel>
 
 @{
     ViewData["Title"] = "Index";
 }
 
 <link href="~/lib/datatable/css/datatables.min.css" rel="stylesheet" />
-
-<div>
-    <h1 class="blue-normal">Seja Bem-vindo</h1>
-    <table id="tableGestor" class="table table-striped">
-        <thead class="blue-normal blue-normal-bg-table">
-            <tr>
-            <tr>
-                <th>CPF</th>
-                <th>Nome</th>
-                <th>Ações</th>
-            </tr>
-        </thead>
-        <tbody>
-        <tbody>
-            @foreach (var item in Model.Gestores)
-            {
+<div class="row">
+    <div class="col-md-12">
+        <table class="table table-striped">
+            <thead class="blue-normal blue-normal-bg-table">
                 <tr>
-                    <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
-                    <td style="vertical-align: middle;">@item.Nome</td>      
-                    <td>
-                       
-                        @Html.ActionLink("Excluir", "Delete", new { id = item.Id, returnUrl = Url.Action("Pessoa") }, new { @class = "btn btn-sm btn-link" })
-                        &nbsp;&nbsp;
-                    </td>
+                    <th>CPF</th>
+                    <th>Nome</th>
+                    <th>Ações</th>
                 </tr>
-            }
-        </tbody>
-    </table>
-
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
+                        <td style="vertical-align: middle;">@item.Nome</td>
+                        <td>
+                            <form id="@(item.Id + "_confirmar")" asp-action="Delete"  asp-route-id="@item.Id">
+                                <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
+                                <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
+                           </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
 </div>
+
+<div class="modal fade" id="modalExcluir" tabindex="-1" role="dialog" aria-labelledby="modalExcluirPessoa" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar exclusão</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
+                </button>
+            </div>
+            <div class="modal-body text-center">
+                <h4>Tem certeza que deseja excluir?</h4>
+                <span class="text-danger fw-bold small">
+                    Essa operação não pode ser desfeita.
+                </span>
+
+            </div>
+            <form method="post" class="modal-footer justify-content-center">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Não</button>
+                <button type="submit" class="btn btn-danger" id="btnConfirmarExclusao">Sim</button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="modalMudarSenha" tabindex="-1" role="dialog" aria-labelledby="modalMudarSenhaPessoa" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title justify-content-center" id="exampleModalLongTitle">Confirmar mudança de senha</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
+                </button>
+            </div>
+            <div class="modal-body text-center">
+                <h4>Tem certeza que deseja mudar a senha?</h4>
+                <span class="text-black-50 fw-bold small">
+                    Vai receber um e-mail para redefinir a senha.
+                </span>
+
+            </div>
+            <div class="modal-footer justify-content-center">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="submit" class="btn btn-danger" id="btnConfirmarMudanca">Sim</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @functions {
+
     public static string FormatarCPF(string cpf)
     {
         if (string.IsNullOrEmpty(cpf) || cpf.Length != 11)
@@ -43,26 +89,5 @@
 
         return Convert.ToUInt64(cpf).ToString(@"000\.000\.000\-00");
     }
-}
 
-@section Scripts {
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="~/lib/datatable/js/datatables.min.js"></script>
-    <script>
-        $(document).ready(function () {
-            $('#tableGestor').DataTable({
-                columnDefs: [
-                    { orderable: true, targets: [0] },
-                    { orderable: false, targets: [1, 2, 3, 4] }
-                ],
-                searching: true,
-                ordering: true,
-                paging: true,
-                language: {
-                    url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
-                }
-            });
-        });
-    </script>
 }

--- a/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
@@ -80,21 +80,7 @@
 
     <div class="container conteudo">
         <main role="main" class="pb-3">
-            @if (TempData["SuccessMessage"] != null)
-            {
-                <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    @TempData["SuccessMessage"]
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            }
-
-            @if (TempData["ErrorMessage"] != null)
-            {
-                <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    @TempData["ErrorMessage"]
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            }
+            <partial name="_MessageText" />
             @RenderBody()
         </main>
     </div>
@@ -110,60 +96,10 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/formHelpers.js"></script>
+    <script src="~/js/modal.js"></script>
+    <script src="~/js/time_message.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
-    <script>
-
-        let idExcluir = null;
-
-        const modalExcluir = document.getElementById('modalExcluir')
-        const btnConfirmarExclusao = document.getElementById('btnConfirmarExclusao');
-        const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
-
-        $(document).ready(function () {
-            setTimeout(function () {
-                $(".alert").fadeOut("slow", function () {
-                    $(this).remove(); 
-                });
-            }, 5000); 
-        });
  
-
-        modalExcluir.addEventListener('show.bs.modal', function (event) {
-          var button = event.relatedTarget
-      
-          idExcluir = button.getAttribute('data-bs-id')
-         
- 
-        })
-        btnConfirmarExclusao.addEventListener('click', function() {
-         
-            executarExclusaoNoServidor(idExcluir);
-            
-            
-            const modalInstance = bootstrap.Modal.getInstance(modalExcluir);
-            modalInstance.hide();
-           
-        });
-
-        function executarExclusaoNoServidor(id) {
-            
-            fetch(`/Pessoa/Delete/${id}`, {
-                    method: 'post' ,
-                    headers: {
-                    
-                    'RequestVerificationToken': token
-                }
-                    }).then(response => {
-                if (response.ok) {
-                   
-                    console.log("Excluído com sucesso!");
-                    location.reload();
-                } else {
-                    console.log("Erro ao excluir.");
-                }
-            }).catch(error => console.error("Erro na requisição:", error));
-        }
-    </script>
 </body>
 
 </html>

--- a/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
@@ -112,6 +112,13 @@
     <script src="~/js/formHelpers.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
     <script>
+
+        let idExcluir = null;
+
+        const modalExcluir = document.getElementById('modalExcluir')
+        const btnConfirmarExclusao = document.getElementById('btnConfirmarExclusao');
+        const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+
         $(document).ready(function () {
             setTimeout(function () {
                 $(".alert").fadeOut("slow", function () {
@@ -119,6 +126,43 @@
                 });
             }, 5000); 
         });
+ 
+
+        modalExcluir.addEventListener('show.bs.modal', function (event) {
+          var button = event.relatedTarget
+      
+          idExcluir = button.getAttribute('data-bs-id')
+         
+ 
+        })
+        btnConfirmarExclusao.addEventListener('click', function() {
+         
+            executarExclusaoNoServidor(idExcluir);
+            
+            
+            const modalInstance = bootstrap.Modal.getInstance(modalExcluir);
+            modalInstance.hide();
+           
+        });
+
+        function executarExclusaoNoServidor(id) {
+            
+            fetch(`/Pessoa/Delete/${id}`, {
+                    method: 'post' ,
+                    headers: {
+                    
+                    'RequestVerificationToken': token
+                }
+                    }).then(response => {
+                if (response.ok) {
+                   
+                    console.log("Excluído com sucesso!");
+                    location.reload();
+                } else {
+                    console.log("Erro ao excluir.");
+                }
+            }).catch(error => console.error("Erro na requisição:", error));
+        }
     </script>
 </body>
 

--- a/Codigo/Evento/EventoWeb/Views/Shared/_MessageText.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_MessageText.cshtml
@@ -1,0 +1,24 @@
+﻿ 
+@if (TempData["SuccessMessage"] != null)
+{
+   <div class="alert alert-success alert-dismissible fade show" role="alert">
+    @TempData["SuccessMessage"]
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+   </div>
+ }
+
+@if (TempData["ErrorMessage"] != null)
+{
+  <div class="alert alert-danger alert-dismissible fade show" role="alert">
+    @TempData["ErrorMessage"]
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+  </div>
+}
+﻿@if (TempData["alertText"] != null && TempData["alertType"] != null)
+{
+   <div class="alert alert-@TempData["alertType"] alert-dismissible fade show d-flex align-items-center" role="alert">
+     <i class="@TempData["alertIcon"] fs-5"></i>
+     <span class="ms-3">@(Html.Raw(TempData["alertText"]?.ToString()))</span>
+     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+   </div>
+}

--- a/Codigo/Evento/EventoWeb/wwwroot/js/modal.js
+++ b/Codigo/Evento/EventoWeb/wwwroot/js/modal.js
@@ -1,0 +1,9 @@
+﻿function showModal(formId, modalId) {
+    if (typeof (formId) === "string" && typeof (modalId) === "string") {
+        form = $(`#${formId}`);
+        modal = $(`#${modalId}`);
+        if (form != null && modal != null) {
+            modal.find("form").attr("action", form.attr("action"));
+        }
+    }
+}

--- a/Codigo/Evento/EventoWeb/wwwroot/js/time_message.js
+++ b/Codigo/Evento/EventoWeb/wwwroot/js/time_message.js
@@ -1,0 +1,7 @@
+﻿$(document).ready(function () {
+    setTimeout(function () {
+        $(".alert").fadeOut("slow", function () {
+            $(this).remove();
+        });
+    }, 5000);
+});

--- a/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
@@ -35,6 +35,9 @@ namespace EventoWeb.Controllers.Tests
                 .Returns(GetTargetPessoa());
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(It.IsAny<Pessoa>(), It.IsAny<int>()))
                 .Returns(Task.CompletedTask);
+            mockService.Setup(service => service.Delete(It.IsAny<uint>()))
+                .Returns(true);
+            mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(GetTargetPessoa(),1));
             mockService.Setup(service => service.Edit(It.IsAny<Pessoa>()))
                 .Returns(Task.CompletedTask); 
             controller = new PessoaController(mockService.Object, mockEstadosbrasilService.Object, mapper);
@@ -192,7 +195,7 @@ namespace EventoWeb.Controllers.Tests
             };
 
             localController.ModelState.Clear();
-
+            
             var result = await localController.Edit(model.Id, model, returnUrl);
 
             Assert.IsInstanceOfType(result, typeof(ViewResult));
@@ -206,7 +209,7 @@ namespace EventoWeb.Controllers.Tests
         public void DeleteTest_Get_Valid()
         {
             string? returnUrl = null;
-            var result = controller!.Delete(GetTargetPessoaModel(), returnUrl);
+            var result = controller!.Delete(GetTargetPessoaModel());
 
             Assert.IsInstanceOfType(result, typeof(ViewResult));
             ViewResult viewResult = (ViewResult)result;
@@ -232,20 +235,44 @@ namespace EventoWeb.Controllers.Tests
         [TestMethod()]
         public void DeleteTest_Post_Valid()
         {
-            string? returnUrl = null;
-            
+                    
             controller!.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext()
             };
             controller.TempData = new TempDataDictionary(controller.HttpContext, Mock.Of<ITempDataProvider>());
 
-            var result = controller!.DeleteConfirmed(GetTargetPessoaModel(), returnUrl);
-            Assert.IsInstanceOfType(result, typeof(ViewResult));
-            ViewResult viewResult = (ViewResult)result;
-            Assert.IsInstanceOfType(viewResult.ViewData.Model, typeof(PessoaModel));
-            
-            
+            var result = controller!.DeleteConfirmed(GetTargetPessoaModel());
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+            RedirectToActionResult redirectToActionResult = (RedirectToActionResult)result;
+            Assert.AreEqual("Index", redirectToActionResult.ActionName);
+
+
+        }
+
+
+        [TestMethod()]
+        public void DeleteAdmTest_Post_Valid()
+        {
+            var pessoa = GetTargetPessoa();
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+{
+                new Claim(ClaimTypes.Name, pessoa.Cpf),
+                new Claim(ClaimTypes.Role, "ADMINISTRADOR")
+            }, "mock"));
+
+            controller!.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext() { User = user }
+            };
+            controller.TempData = new TempDataDictionary(controller.HttpContext, Mock.Of<ITempDataProvider>());
+
+            var result = controller!.DeleteConfirmed(GetTargetPessoaModel());
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+            RedirectToActionResult redirectToActionResult = (RedirectToActionResult)result;
+            Assert.AreEqual("DefinirAdministrador", redirectToActionResult.ActionName);
+
+
         }
 
         private PessoaModel GetNewPessoa()

--- a/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
@@ -37,7 +37,7 @@ namespace EventoWeb.Controllers.Tests
                 .Returns(Task.CompletedTask);
             mockService.Setup(service => service.Delete(It.IsAny<uint>()))
                 .Returns(true);
-            mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(GetTargetPessoa(),1));
+            mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(GetTargetPessoa(),1,1));
             mockService.Setup(service => service.Edit(It.IsAny<Pessoa>()))
                 .Returns(Task.CompletedTask); 
             controller = new PessoaController(mockService.Object, mockEstadosbrasilService.Object, mapper);


### PR DESCRIPTION
A tela de administrador foi removida e substituída por uma nova implementação baseada no protótipo. As ações de editar e detalhes foram retiradas, e a exclusão agora ocorre via modal de confirmação, sem redirecionamento de página.

A listagem de administradores e os modais foram centralizados na página Index, permitindo reutilização em outras telas, como a de gestor, que possui apenas um formulário de cadastro e reutiliza essa listagem.

 Scripts externos foram adicionados para gerenciar modais e tempo de mensagens, melhorando a organização do código. Também foi criado um componente para exibir mensagens de alerta usando TempData.

**Observação: Foi incluído o botão de alteração de senha com popup de confirmação, porém ainda sem funcionalidade, que será implementada futuramente.**

**Os testes estão executando com sucesso.**