### PR TITLE
Padronizando tabela de manter ADM

### DIFF
--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -31,7 +31,7 @@
 					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
 						<div class="form-group mb-4">
 							<label asp-for="Telefone1" class="control-label">Telefone</label>
-							<input asp-for="Telefone1" type="number" class="form-control" id="Telefone1" placeholder="Com o DDD" />
+							<input asp-for="Telefone1" type="tel" class="form-control" id="Telefone1" placeholder="Com o DDD" />
 							<span asp-validation-for="Telefone1" class="text-danger"></span>
 						</div>
 					</div>
@@ -57,3 +57,4 @@
 </div>
 
 <partial name="Index" model="Model.Administradores" />
+

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -30,7 +30,7 @@
 					</div>
 					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
 						<div class="form-group mb-4">
-							<label asp-for="Telefone1" class="control-label">Telefone</label>
+							<label asp-for="Telefone1" class="control-label">Celular</label>
 							<input asp-for="Telefone1" type="tel" class="form-control" id="Telefone1" placeholder="Com o DDD" />
 							<span asp-validation-for="Telefone1" class="text-danger"></span>
 						</div>
@@ -44,7 +44,7 @@
 					</div>
 					<div class="row">
 						<div class="d-flex flex-row-reverse mb-4">
-							<button type="submit" class="btn btn-lg btn-blue-normal">Adicionar Administrador</button>
+							<button type="submit" class="btn btn-lg btn-blue-normal">Adicionar Administrador do sistema</button>
 						</div>
 					</div>
 				</div>

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -7,7 +7,7 @@
 <link href="~/lib/datatable/css/datatables.min.css" rel="stylesheet" />
 <div class="row">
     <div class="col-md-12">
-        <table class="table table-striped">
+        <table id="tablePessoa" class="table table-striped">
             <thead class="blue-normal blue-normal-bg-table">
                 <tr>
                     <th>CPF</th>
@@ -23,8 +23,11 @@
                         <td style="vertical-align: middle;">@item.Nome</td>
                         <td>
                             <form id="@(item.Id + "_confirmar")" asp-action="Delete"  asp-route-id="@item.Id">
-                                <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
-                                <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
+                                <div class="d-flex flex-wrap gap-2">
+                                    <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
+                                    <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
+                                </div>
+                                
                            </form>
                         </td>
                     </tr>
@@ -79,6 +82,7 @@
         </div>
     </div>
 </div>
+
 
 @functions {
 

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -34,8 +34,14 @@
                 }
             </tbody>
         </table>
+        <div class="d-flex flex-row-reverse mt-4 mb-4">
+            <a asp-controller="Home" asp-action="Index" class="btn btn-lg btn-blue-normal">Voltar</a>
+        </div>
     </div>
 </div>
+
+
+
 
 <div class="modal fade" id="modalExcluir" tabindex="-1" role="dialog" aria-labelledby="modalExcluirPessoa" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">

--- a/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
@@ -33,9 +33,6 @@
                                 <a class="nav-link opcao" asp-area="" asp-controller="AreaInteresse" asp-action="Index">Áreas Interesse</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link opcao" asp-controller="Pessoa" asp-action="GestoresSistema">Gestores Sistema</a>
-                            </li>
-                            <li class="nav-item">
                                 <a class="nav-link opcao" asp-controller="Pessoa" asp-action="DefinirAdministrador">Administradores</a>
                             </li>
                         </ul>
@@ -98,6 +95,8 @@
     <script src="~/js/formHelpers.js"></script>
     <script src="~/js/modal.js"></script>
     <script src="~/js/time_message.js"></script>
+    <script src="~/lib/datatable/js/datatables.min.js"></script>
+    <script src="~/js/datatables.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
  
 </body>

--- a/Codigo/Evento/EventoWeb/wwwroot/js/datatables.js
+++ b/Codigo/Evento/EventoWeb/wwwroot/js/datatables.js
@@ -1,0 +1,15 @@
+﻿$(document).ready(function () {
+	$('#tablePessoa').DataTable({
+		order: [[1, 'asc']],
+		columnDefs: [
+			{ orderable: true, targets: [1] },
+			{ orderable: false, targets: [0,2] }
+		],
+		searching: true,
+		ordering: true,
+		paging: true,
+		language: {
+			url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
+		}
+	});
+});


### PR DESCRIPTION
A tela de manter administrador foi padronizada para ficar igual ao protótipo. 
Foi adicionado um datatables para tornar a tabela dinâmica e igual as outras telas, o menu foi alterado e a label para digitar telefone foi corrigida. #578 