### PR TITLE
Tratando erro de duplicação e corrigindo erro de adicionar adm

### DIFF
--- a/Codigo/Evento/Core/Service/IPessoaService.cs
+++ b/Codigo/Evento/Core/Service/IPessoaService.cs
@@ -1,7 +1,3 @@
-using Core.DTO;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace Core.Service
 {
 
@@ -14,10 +10,11 @@ namespace Core.Service
         Pessoa Get(uint id);
         IEnumerable<Pessoa> GetAll();
         Pessoa GetByCpf(string cpf);
+        Task<bool> IsAdmAsync(Pessoa pessoa);
         Task<List<Pessoa>> GetAllAdmAsync();
         Task<List<Pessoa>> GetAllGestorAsync();
         Task<UsuarioIdentity> CreateAsync(Pessoa pessoa);
-        Task CreatePessoaIdentityComPapelAsync(Pessoa pessoa, uint idEvento, int idPapel);
+        Task <bool> CreatePessoaIdentityComPapelAsync(Pessoa pessoa, uint idEvento, int idPapel);
         Task<List<Pessoa>> GetPessoasPorPapelNoEventoAsync(uint idEvento, int idPapel);
 
     }

--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -5,6 +5,7 @@ using EventoWeb.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Net;
 
 namespace EventoWeb.Controllers
 {
@@ -256,6 +257,7 @@ namespace EventoWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> DefinirAdministrador(GestaoAdministradorModel viewModel)
         {
+           
             if (ModelState.IsValid)
             {
                 var pessoa = new Pessoa
@@ -267,9 +269,25 @@ namespace EventoWeb.Controllers
                     Email = viewModel.Email
                 };
 
-                
-                await _pessoaService.CreatePessoaIdentityComPapelAsync(pessoa,0 ,1);
-                TempData["SuccessMessage"] = "Administrador definido com sucesso.";
+                if (await _pessoaService.IsAdmAsync(pessoa))
+                {
+                    TempData["ErrorMessage"] = "Já existe um administrador cadastrado com esse CPF.";
+                }
+                else
+                {
+                    var sucesso = await _pessoaService.CreatePessoaIdentityComPapelAsync(pessoa, 0, 1);
+
+                    if (sucesso)
+                    {
+                        TempData["SuccessMessage"] = "Administrador definido com sucesso.";
+                    }
+                    else
+                    {
+                        TempData["ErrorMessage"] = "Erro ao cadastrar administrador.";
+                    }
+
+                }
+
                 return RedirectToAction(nameof(DefinirAdministrador));
                
             }

--- a/Codigo/Evento/EventoWebTests/Controllers/EventoControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/EventoControllerTests.cs
@@ -59,7 +59,7 @@ namespace EventoWeb.Controllers.Tests
                 .Returns((uint idPessoa, uint idEvento) => 1);
             mockServicePessoa.Setup(service => service.CreatePessoaIdentityComPapelAsync(
     It.IsAny<Pessoa>(), It.IsAny<uint>(), It.IsAny<int>()))
-    .Returns(Task.CompletedTask)
+    .ReturnsAsync(true)
                 .Verifiable();
             mockService.Setup(service => service.AtualizarVagasDisponiveis(It.IsAny<uint>()))
                 .Verifiable();

--- a/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
@@ -34,7 +34,7 @@ namespace EventoWeb.Controllers.Tests
             mockService.Setup(service => service.Get(1))
                 .Returns(GetTargetPessoa());
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(It.IsAny<Pessoa>(), It.IsAny<uint>(), It.IsAny<int>()))
-                .Returns(Task.CompletedTask);
+                .ReturnsAsync(true);
             mockService.Setup(service => service.Delete(It.IsAny<uint>()))
                 .Returns(true);
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(GetTargetPessoa(),1,1));
@@ -98,7 +98,7 @@ namespace EventoWeb.Controllers.Tests
             controller!.ModelState.Clear();
             var mockService = new Mock<IPessoaService>();
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(It.IsAny<Pessoa>(), It.IsAny<uint>(), It.IsAny<int>()))
-                .Returns(Task.CompletedTask);
+                .ReturnsAsync(true);
 
             controller = new PessoaController(mockService.Object, new Mock<IEstadosbrasilService>().Object,
             new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper());

--- a/Codigo/Evento/Service/PessoaService.cs
+++ b/Codigo/Evento/Service/PessoaService.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.Data;
 using System.Diagnostics;
+using System.Net;
 
 namespace Service;
 
@@ -22,6 +23,7 @@ public class PessoaService : IPessoaService
 
     public uint Create(Pessoa pessoa)
     {
+        
         try
         {
             _context.Add(pessoa);
@@ -126,6 +128,15 @@ public class PessoaService : IPessoaService
     public Pessoa GetByCpf(string cpf)
         => _context.Pessoas.SingleOrDefault(p => p.Cpf == cpf);
 
+    public async Task<bool>IsAdmAsync(Pessoa pessoa)
+    {
+        var user = await _userManager.FindByNameAsync(pessoa.Cpf);
+
+        if (user == null)
+            return false;
+
+        return await _userManager.IsInRoleAsync(user, "ADMINISTRADOR");
+    }
     public async Task<UsuarioIdentity> CreateAsync(Pessoa pessoa)
     {
         var novoUsuario = new UsuarioIdentity
@@ -148,20 +159,27 @@ public class PessoaService : IPessoaService
         return novoUsuario;
     }
 
-    public async Task CreatePessoaIdentityComPapelAsync(Pessoa pessoa, uint idEvento, int idPapel)
+    public async Task<bool> CreatePessoaIdentityComPapelAsync(Pessoa pessoa, uint idEvento, int idPapel)
     {
+        bool sucesso = false;
         uint idPessoa = pessoa.Id;
-        if (GetByCpf(pessoa.Cpf) == null)
-        {
-            return;
-        }
-
         var existingUser = await _userManager.FindByNameAsync(pessoa.Cpf);
 
-        if (existingUser == null)
+        if(idPapel == 1 && existingUser == null && GetByCpf(pessoa.Cpf) == null)
         {
-            return;
+                Create(pessoa);
+                await CreateAsync(pessoa);
+                existingUser = await _userManager.FindByNameAsync(pessoa.Cpf);
+                sucesso = true;
+
         }
+
+        if (GetByCpf(pessoa.Cpf) == null || existingUser == null)
+        {
+            return sucesso;
+
+        }
+        
 
         if (idEvento > 0)
         {
@@ -193,12 +211,16 @@ public class PessoaService : IPessoaService
                 if (!await _userManager.IsInRoleAsync(existingUser, role))
                 {
                     var roleResult = await _userManager.AddToRoleAsync(existingUser, role);
+                    sucesso = true;
                     if (!roleResult.Succeeded)
                     {
                         var errors = string.Join("; ", roleResult.Errors.Select(e => e.Description));
                         throw new Exception($"Erro ao associar o papel '{role.ToLower()}' ao usuário no Identity: {errors}");
+                        
                     }
                 }
+
+                
 
                 await transaction.CommitAsync();
             }
@@ -207,6 +229,8 @@ public class PessoaService : IPessoaService
                 await transaction.RollbackAsync();
                 throw new Exception($"Erro ao criar pessoa, inscrição ou associar papel: {ex.Message}", ex);
             }
+
+            return sucesso;
         }
     }
 


### PR DESCRIPTION
O método `IsAdmAsync` foi adicionado na interface `IPessoaService` e implementado na classe `PessoaService`, serve para verificar se a pessoa em questão já é um administrador. O método `CreatePessoaIdentityComPapelAsync` foi alterado para retornar `Task<bool>`,  a lógica foi atualizada para cadastrar uma pessoa apenas quando a for atribuir papel de administrador  e quando a mesma não estiver no banco. Vai retornar um indicador de sucesso ao criar identidades e atribuir funções. O  `PessoaController` foi atualizado para verificar se a pessoa  já é um adm (`IsAdmAsync`) antes definir como administrador, resulta em mensagens de sucesso ou erro via `TempData`.  Os testes foram atualizados para simular  o novo retorno booleano (`ReturnsAsync(true)`). e fiz ajuste as diretivas `using` removendo e adicionando algumas. #577

**O sistema ainda apresenta erro ao excluir uma pessoa que apresenta múltiplos papéis, mas corrigir esse problema não é o objetivo da issues #577** 