### PR TITLE
Redirecionar para CreateGestor e Ajustar a inicialização do DataTable

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/EventoController.cs
@@ -274,7 +274,7 @@ namespace EventoWeb.Controllers
                 await _pessoaService.CreatePessoaIdentityComPapelAsync(pessoaExistente, idEvento, 2);
                 _eventoService.AtualizarVagasDisponiveis(idEvento);
 
-                return RedirectToAction("GerenciarEvento", new { idEvento });
+                return RedirectToAction("CreateGestor", new { idEvento });
             }
 
             gestaoPapelModel.Evento = _eventoService.GetEventoSimpleDto(gestaoPapelModel.Evento.Id);

--- a/Codigo/Evento/EventoWeb/Views/Evento/CreateGestor.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Evento/CreateGestor.cshtml
@@ -171,23 +171,23 @@
 }
 
 @section Scripts {
-	<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-	<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 	<script src="~/lib/datatable/js/datatables.min.js"></script>
 	<script>
 		$(document).ready(function () {
-		$('#tablePessoa').DataTable({
-		columnDefs: [
-		{ orderable: true, targets: [0] },
-		{ orderable: false, targets: [1, 2] }
-		],
-		searching: true,
-		ordering: true,
-		paging: true,
-		language: {
-		url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
-		}
-		});
+			if (!$.fn.DataTable.isDataTable('#tablePessoa')) {
+				$('#tablePessoa').DataTable({
+					columnDefs: [
+						{ orderable: true, targets: [0] },
+						{ orderable: false, targets: [1, 2] }
+					],
+					searching: true,
+					ordering: true,
+					paging: true,
+					language: {
+						url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
+					}
+				});
+			}
 		});
 	</script>
 }

--- a/Codigo/Evento/EventoWeb/Views/Evento/CreateGestor.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Evento/CreateGestor.cshtml
@@ -169,25 +169,3 @@
 		return Convert.ToUInt64(cpf).ToString(@"000\.000\.000\-00");
 	}
 }
-
-@section Scripts {
-	<script src="~/lib/datatable/js/datatables.min.js"></script>
-	<script>
-		$(document).ready(function () {
-			if (!$.fn.DataTable.isDataTable('#tablePessoa')) {
-				$('#tablePessoa').DataTable({
-					columnDefs: [
-						{ orderable: true, targets: [0] },
-						{ orderable: false, targets: [1, 2] }
-					],
-					searching: true,
-					ordering: true,
-					paging: true,
-					language: {
-						url: '@Url.Content("~/lib/datatable/js/pt-BR.json")'
-					}
-				});
-			}
-		});
-	</script>
-}

--- a/Codigo/Evento/EventoWebTests/Controllers/EventoControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/EventoControllerTests.cs
@@ -252,7 +252,7 @@ namespace EventoWeb.Controllers.Tests
 
             Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
             RedirectToActionResult redirectToActionResult = (RedirectToActionResult)result;
-            Assert.AreEqual("GerenciarEvento", redirectToActionResult.ActionName);
+            Assert.AreEqual("CreateGestor", redirectToActionResult.ActionName);
         }
 
         [TestMethod()]


### PR DESCRIPTION
Atualiza o EventoController para redirecionar para CreateGestor (em vez de GerenciarEvento) após associar uma pessoa existente e atualizar as vagas do evento. Modifica a CreateGestor.cshtml para remover as tags de script explícitas do jQuery/Bootstrap e envolve a inicialização do DataTable em uma verificação $.fn.DataTable.isDataTable para evitar dupla inicialização e erros de JS correlacionados quando scripts/partials são carregados múltiplas vezes.