### PR TITLE
Implementando função de mudar senha para Adm

### DIFF
--- a/Codigo/Evento/Core/Service/IPessoaService.cs
+++ b/Codigo/Evento/Core/Service/IPessoaService.cs
@@ -11,6 +11,8 @@ namespace Core.Service
         IEnumerable<Pessoa> GetAll();
         Pessoa GetByCpf(string cpf);
         Task<bool> IsAdmAsync(Pessoa pessoa);
+        public bool EmailConfirmado(string email);
+        Task<string> GerarTokenAsync(String cpf);
         Task<List<Pessoa>> GetAllAdmAsync();
         Task<List<Pessoa>> GetAllGestorAsync();
         Task<UsuarioIdentity> CreateAsync(Pessoa pessoa);

--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -3,9 +3,15 @@ using Core;
 using Core.Service;
 using EventoWeb.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Primitives;
+using NuGet.Common;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace EventoWeb.Controllers
 {
@@ -16,15 +22,19 @@ namespace EventoWeb.Controllers
         private readonly IPessoaService _pessoaService;
         private readonly IEstadosbrasilService _estadosbrasilService;
         private readonly IMapper _mapper;
+        private readonly IEmailSender _emailSender;
+
 
         public PessoaController(
             IPessoaService pessoaService,
             IEstadosbrasilService estadosbrasilService,
-            IMapper mapper)
+            IMapper mapper, IEmailSender emailSender)   
         {
             _pessoaService = pessoaService;
             _estadosbrasilService = estadosbrasilService;
             _mapper = mapper;
+           _emailSender = emailSender;    
+            
         }
 
         // =====================================================================
@@ -295,6 +305,46 @@ namespace EventoWeb.Controllers
             var adminsAtuais = await _pessoaService.GetAllAdmAsync();
             viewModel.Administradores = _mapper.Map<List<PessoaModel>>(adminsAtuais.OrderBy(p => p.Nome).ToList());
             return View(viewModel);
+        }
+       
+        [HttpPost, ActionName("EnviarEmailSenha")]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> EnviarEmailSenha(PessoaModel viewModel)
+        {
+           
+            string email = viewModel.Email;
+
+
+            if (_pessoaService.GetByCpf(viewModel.Cpf) == null)
+            {
+                TempData["ErrorMessage"] = "Usuário não encontrado.";
+                return RedirectToAction(nameof(DefinirAdministrador));
+            }
+
+            if (!_pessoaService.EmailConfirmado(email))
+            {
+                TempData["ErrorMessage"] = "E-mail do usuário não confirmado.";
+                return RedirectToAction(nameof(DefinirAdministrador));
+            }
+
+            String token = await _pessoaService.GerarTokenAsync(viewModel.Cpf);
+
+
+           var callbackUrl = Url.Action(
+           action: "ResetPassword",
+           controller: "Account",
+           values: new { email = email, token = token },
+           protocol: Request.Scheme);
+
+            string assunto = "Redefinição de Senha";
+            string mensagemHtml = $@" <h2>Olá!</h2>    
+                                    <p>Bora lá alterar sua senha!</p>
+                                    <p>Para redefinir seu acesso, <a href='{callbackUrl}'>clique aqui</a>.</p><br>
+                                    <p><small>Se você não solicitou essa alteração, por favor, ignore este e-mail.</small></p>";
+            await _emailSender.SendEmailAsync(email, assunto, mensagemHtml);
+
+            TempData["SuccessMessage"] = "E-mail de redefinição enviado com sucesso!";
+            return RedirectToAction(nameof(DefinirAdministrador));
         }
 
         // =====================================================================

--- a/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/PessoaController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Primitives;
 using NuGet.Common;
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -312,36 +313,39 @@ namespace EventoWeb.Controllers
         public async Task<ActionResult> EnviarEmailSenha(PessoaModel viewModel)
         {
            
-            string email = viewModel.Email;
-
-
-            if (_pessoaService.GetByCpf(viewModel.Cpf) == null)
+            Pessoa pessoa = _pessoaService.Get(viewModel.Id);
+           
+            if (pessoa == null)
             {
                 TempData["ErrorMessage"] = "Usuário não encontrado.";
+                return RedirectToAction(nameof(DefinirAdministrador));
+            }
+            string email = pessoa.Email;
+            var validadorDeEmail = new EmailAddressAttribute();
+
+            if (!validadorDeEmail.IsValid(email))
+            {
+                TempData["ErrorMessage"] = "Não é possível enviar a mensagem, o email está incorreto.";
                 return RedirectToAction(nameof(DefinirAdministrador));
             }
 
             if (!_pessoaService.EmailConfirmado(email))
             {
-                TempData["ErrorMessage"] = "E-mail do usuário não confirmado.";
+                TempData["ErrorMessage"] = "E-mail não foi confirmado.";
                 return RedirectToAction(nameof(DefinirAdministrador));
             }
+            
+           String token = await _pessoaService.GerarTokenAsync(pessoa.Cpf);
 
-            String token = await _pessoaService.GerarTokenAsync(viewModel.Cpf);
 
-
-           var callbackUrl = Url.Action(
-           action: "ResetPassword",
-           controller: "Account",
-           values: new { email = email, token = token },
-           protocol: Request.Scheme);
+            var callbackUrl = Url.Page(
+            pageName: "/Account/ResetPassword",
+            pageHandler: null,
+            values: new { area = "Identity", code = token }, 
+            protocol: Request.Scheme);
 
             string assunto = "Redefinição de Senha";
-            string mensagemHtml = $@" <h2>Olá!</h2>    
-                                    <p>Bora lá alterar sua senha!</p>
-                                    <p>Para redefinir seu acesso, <a href='{callbackUrl}'>clique aqui</a>.</p><br>
-                                    <p><small>Se você não solicitou essa alteração, por favor, ignore este e-mail.</small></p>";
-            await _emailSender.SendEmailAsync(email, assunto, mensagemHtml);
+            string mensagemHtml = $@"<h2>Olá, {pessoa.Nome}!</h2><p>Bora lá alterar sua senha?</p><p>Para redefinir seu acesso, <a href='{callbackUrl}'>clique aqui</a>.</p><br><p><small>Se você não solicitou essa alteração, por favor, ignore este e-mail.</small></p>"; await _emailSender.SendEmailAsync(email, assunto, mensagemHtml);
 
             TempData["SuccessMessage"] = "E-mail de redefinição enviado com sucesso!";
             return RedirectToAction(nameof(DefinirAdministrador));

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -78,7 +78,7 @@
             <div class="modal-body text-center">
                 <h4>Tem certeza que deseja mudar a senha?</h4>
                 <span class="text-black-50 fw-bold small">
-                    Vai receber um e-mail para redefinir a senha.
+                    Essa pessoa vai receber um e-mail para redefinir a senha.
                 </span>
 
             </div>

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -22,13 +22,14 @@
                         <td style="vertical-align: middle;">@FormatarCPF(@item.Cpf)</td>
                         <td style="vertical-align: middle;">@item.Nome</td>
                         <td>
-                            <form id="@(item.Id + "_confirmar")" asp-action="Delete"  asp-route-id="@item.Id">
-                                <div class="d-flex flex-wrap gap-2">
-                                    <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
-                                    <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
-                                </div>
-                                
-                           </form>
+                            <div class="d-flex flex-wrap gap-2">
+                                <form id="@(item.Id + "_confirmar")" asp-action="Delete"  asp-route-id="@item.Id">
+                                   <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
+                                </form>
+                                <form id="@(item.Id + "_confirmar")" asp-action="EnviarEmailSenha" asp-route-id="@item.Email">
+                                      <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
+                                </form>
+                            </div>
                         </td>
                     </tr>
                 }
@@ -81,10 +82,10 @@
                 </span>
 
             </div>
-            <div class="modal-footer justify-content-center">
+            <form method="post" class="modal-footer justify-content-center">
                 <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Cancelar</button>
                 <button type="submit" class="btn btn-danger" id="btnConfirmarMudanca">Sim</button>
-            </div>
+            </form>
         </div>
     </div>
 </div>

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/Index.cshtml
@@ -26,8 +26,8 @@
                                 <form id="@(item.Id + "_confirmar")" asp-action="Delete"  asp-route-id="@item.Id">
                                    <button type="button" class="btn btn-danger" onclick="showModal('@(item.Id + "_confirmar")','modalExcluir')" data-bs-toggle="modal" data-bs-target="#modalExcluir" data-bs-id="@item.Id">Excluir</button>
                                 </form>
-                                <form id="@(item.Id + "_confirmar")" asp-action="EnviarEmailSenha" asp-route-id="@item.Email">
-                                      <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modalMudarSenha">Mudar Senha</button>
+                                <form id="@(item.Id + "_redefinir")" asp-action="EnviarEmailSenha" asp-route-id="@item.Id">
+                                    <button type="button" class="btn btn-secondary" onclick="showModal('@(item.Id + "_redefinir")','modalMudarSenha')" data-bs-toggle="modal" data-bs-target="#modalMudarSenha" data-bs-id="@item.Id">Mudar Senha</button>
                                 </form>
                             </div>
                         </td>

--- a/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
+++ b/Codigo/Evento/EventoWebTests/Controllers/PessoaControllerTests.cs
@@ -29,6 +29,8 @@ namespace EventoWeb.Controllers.Tests
             IMapper mapper = new MapperConfiguration(cfg =>
             cfg.AddProfile(new PessoaProfile())).CreateMapper();
 
+            var IEmailSenderMock = new Mock<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender>();
+
             mockService.Setup(service => service.GetAll())
                 .Returns(GetTestPessoas());
             mockService.Setup(service => service.Get(1))
@@ -39,8 +41,8 @@ namespace EventoWeb.Controllers.Tests
                 .Returns(true);
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(GetTargetPessoa(),1,1));
             mockService.Setup(service => service.Edit(It.IsAny<Pessoa>()))
-                .Returns(Task.CompletedTask); 
-            controller = new PessoaController(mockService.Object, mockEstadosbrasilService.Object, mapper);
+                .Returns(Task.CompletedTask);
+            controller = new PessoaController(mockService.Object, mockEstadosbrasilService.Object, mapper, IEmailSenderMock.Object);
         }
 
         [TestMethod()]
@@ -99,9 +101,9 @@ namespace EventoWeb.Controllers.Tests
             var mockService = new Mock<IPessoaService>();
             mockService.Setup(service => service.CreatePessoaIdentityComPapelAsync(It.IsAny<Pessoa>(), It.IsAny<uint>(), It.IsAny<int>()))
                 .ReturnsAsync(true);
-
+            var IEmailSenderMock = new Mock<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender>();
             controller = new PessoaController(mockService.Object, new Mock<IEstadosbrasilService>().Object,
-            new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper());
+            new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper(), IEmailSenderMock.Object);
 
             var result = await controller.Create(GetNewPessoa(), returnUrl);
 
@@ -118,9 +120,10 @@ namespace EventoWeb.Controllers.Tests
             string? returnUrl = null;
             controller!.ModelState.Clear();
             var mockService = new Mock<IPessoaService>();
+            var IEmailSenderMock = new Mock<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender>();
 
             controller = new PessoaController(mockService.Object, new Mock<IEstadosbrasilService>().Object,
-            new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper());
+            new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper(), IEmailSenderMock.Object);
 
             controller.ModelState.AddModelError("Nome", "Campo requerido");
             controller.ModelState.AddModelError("NomeCracha", "Campo requerido");
@@ -145,9 +148,9 @@ namespace EventoWeb.Controllers.Tests
             var mockService = new Mock<IPessoaService>();
             var mockEstadosService = new Mock<IEstadosbrasilService>();
             mockService.Setup(service => service.Get(pessoa.Id)).Returns(pessoa);
-
+            var IEmailSenderMock = new Mock<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender>();
             var mapper = new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper();
-            var localController = new PessoaController(mockService.Object, mockEstadosService.Object, mapper);
+            var localController = new PessoaController(mockService.Object, mockEstadosService.Object, mapper, IEmailSenderMock.Object);
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
             {
@@ -179,9 +182,9 @@ namespace EventoWeb.Controllers.Tests
             var mockService = new Mock<IPessoaService>();
             mockService.Setup(service => service.Get(model.Id)).Returns(pessoa);
             mockService.Setup(service => service.Edit(It.IsAny<Pessoa>())).Verifiable();
-
+            var IEmailSenderMock = new Mock<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender>();
             var mapper = new MapperConfiguration(cfg => cfg.AddProfile(new PessoaProfile())).CreateMapper();
-            var localController = new PessoaController(mockService.Object, new Mock<IEstadosbrasilService>().Object, mapper);
+            var localController = new PessoaController(mockService.Object, new Mock<IEstadosbrasilService>().Object, mapper, IEmailSenderMock.Object);
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
             {

--- a/Codigo/Evento/Service/PessoaService.cs
+++ b/Codigo/Evento/Service/PessoaService.cs
@@ -2,10 +2,12 @@ using Core;
 using Core.Service;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Org.BouncyCastle.Asn1.Ocsp;
 using System.Data;
 using System.Diagnostics;
 using System.Net;
-
+using System.Security.Policy;
+using System.Threading.Tasks;
 namespace Service;
 
 public class PessoaService : IPessoaService
@@ -13,10 +15,10 @@ public class PessoaService : IPessoaService
     private readonly EventoContext _context;
     private readonly UserManager<UsuarioIdentity> _userManager;
     private readonly IInscricaoService _inscricaoService;
-
+    
     public PessoaService(UserManager<UsuarioIdentity> userManager, EventoContext context, IInscricaoService inscricaoService)
     {
-        _userManager = userManager;
+        _userManager = userManager; 
         _context = context;
         _inscricaoService = inscricaoService;
     }
@@ -137,6 +139,31 @@ public class PessoaService : IPessoaService
 
         return await _userManager.IsInRoleAsync(user, "ADMINISTRADOR");
     }
+
+    public bool EmailConfirmado(string email)
+    {
+        var user = _userManager.FindByEmailAsync(email).Result;
+        if (user == null)
+            return false;
+        var isConfirmed = _userManager.IsEmailConfirmedAsync(user).Result;
+        return isConfirmed;
+    }
+
+    public async Task<string> GerarTokenAsync(String cpf)
+    {
+        String token = "";
+        var user = await _userManager.FindByNameAsync(cpf);
+
+        if (user == null)
+            return token;
+        token = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+        return token;
+
+
+
+    }
+
     public async Task<UsuarioIdentity> CreateAsync(Pessoa pessoa)
     {
         var novoUsuario = new UsuarioIdentity

--- a/Codigo/Evento/Service/PessoaService.cs
+++ b/Codigo/Evento/Service/PessoaService.cs
@@ -148,7 +148,6 @@ public class PessoaService : IPessoaService
         var isConfirmed = _userManager.IsEmailConfirmedAsync(user).Result;
         return isConfirmed;
     }
-
     public async Task<string> GerarTokenAsync(String cpf)
     {
         String token = "";


### PR DESCRIPTION
Foi implementado uma lógica para mudar a senha de um administrador.
O botão de "Mudar Senha", localizado na tela de definir Administrador está funcional e pode ser utilizado para enviar um email de redefinição de senha ao usuário, caso o email do mesmo esteja confirmado e caso o email esteja correto (ex: bea@contato.com, juju@gmail.com etc). Alem disso, fiz algumas alterações nas páginas html para executar o modal e passar o id da pessoa como parâmetro. #580 