### PR TITLE
Corriji a lista vazia do select de adicionar tipo inscrição em subevento

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
@@ -185,16 +185,17 @@ namespace EventoWeb.Controllers
         // POST: /TipoInscricao/CreateTipoInscricaoSubevento
         [HttpPost("CreateTipoInscricaoSubevento")]
         [ValidateAntiForgeryToken]
-        public ActionResult CreateTipoInscricaoSubevento(uint idSubevento, uint IdTipoInscricao)
+        public ActionResult CreateTipoInscricaoSubevento(TipoInscricaoSubeventoModel model)
         {
-            if (IdTipoInscricao == 0)
+
+            if (!ModelState.IsValid)
             {
                 ModelState.AddModelError("", "Por favor, selecione um Tipo de Inscrição válido.");
 
-                var subevento = _subeventoService.Get(idSubevento);
+                var subevento = _subeventoService.Get(model.Subevento.Id);
                 var subeventoModel = _mapper.Map<SubeventoModel>(subevento);
                 var tiposInscricaos = _tipoInscricaoService.GetByEventoUsadaSubevento(subevento.IdEvento);
-                var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(idSubevento);
+                var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(model.Subevento.Id);
 
                 ViewData["EventoId"] = subevento.IdEvento;
 
@@ -207,8 +208,8 @@ namespace EventoWeb.Controllers
                 return View(view);
             }
 
-            _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(idSubevento, IdTipoInscricao);
-            return RedirectToAction("CreateTipoInscricaoSubevento", new { idSubevento });
+            _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(model.Subevento.Id, model.IdTipoInscricao);
+            return RedirectToAction("CreateTipoInscricaoSubevento", new { model.Subevento.Id });
         }
 
         // POST: /TipoInscricao/DeleteTipoInscricaoSubevento

--- a/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
@@ -187,7 +187,6 @@ namespace EventoWeb.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult CreateTipoInscricaoSubevento(TipoInscricaoSubeventoModel model)
         {
-
             if (!ModelState.IsValid)
             {
                 ModelState.AddModelError("", "Por favor, selecione um Tipo de Inscrição válido.");

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/Create.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/Create.cshtml
@@ -78,12 +78,10 @@
                             <div class="form-group mb-2">
                                 <div class="d-flex align-items-center">
                                     <div class="form-check">
-                                        <!-- Checkbox que marca se o evento ser� usado (valor 1) -->
                                         <input class="form-check-input" type="checkbox" value="1" id="UsadaEvento" name="TipoInscricao.UsadaEvento"
                                         @(Model.UsadaEvento == 1 ? "checked" : "")>
                                         <label class="form-check-label" for="UsadaEvento">Usado em Evento</label>
-                                        <!-- Campo oculto para enviar valor 0 quando o checkbox n�o est� marcado -->
-                                        <input type="hidden" name="TipoInscricao.UsadaEvento" value="0">
+                                        <input type="hidden" name="UsadaEvento" value="0">
                                     </div>
                                 </div>
                                 <span asp-validation-for="UsadaEvento" class="text-danger"></span>

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/Create.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/Create.cshtml
@@ -93,12 +93,10 @@
                             <div class="form-group mb-3">
                                 <div class="d-flex align-items-center">
                                     <div class="form-check">
-                                        <!-- Checkbox que marca se o subevento ser� usado (valor 1) -->
-                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaSubevento" name="TipoInscricao.UsadaSubevento"
+                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaSubevento" name="UsadaSubevento"
                                         @(Model.UsadaSubevento == 1 ? "checked" : "")>
                                         <label class="form-check-label" for="UsadaSubevento">Usado em Subevento</label>
-                                        <!-- Campo oculto para enviar valor 0 quando o checkbox n�o est� marcado -->
-                                        <input type="hidden" name="TipoInscricao.UsadaSubevento" value="0">
+                                        <input type="hidden" name="UsadaSubevento" value="0">
                                     </div>
                                 </div>
                                 <span asp-validation-for="UsadaSubevento" class="text-danger"></span>

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
@@ -21,16 +21,10 @@
                     @Html.AntiForgeryToken()
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="row">
-                        <!--<div class="col-2">
-                            <div class="form-group">
-                                
-                            </div>
-                        </div>-->
                             <div class="col-3">
                                 <div class="form-group">
                                     <label for="IdSubevento" class="control-label">Subevento</label>
-                                    <input type="hidden" name="idSubevento" value="@Model?.Subevento?.Id" />
-
+                                    <input type="hidden" name="Subevento.Id" value="@Model?.Subevento?.Id" />
                                     <select class="form-control" disabled>
                                         @if (Model?.Subevento?.Id == null || Model.Subevento.Id == 0)
                                         {
@@ -43,18 +37,11 @@
                                     </select>
                                 </div>
                             </div>
-                    <!--</div>
-                    <div class="row">-->    
-                        <!--<div class="col-2">
-                            <div class="form-group">
-                                
-                            </div>
-                        </div>-->
                         <div class="col-4">
                             <div class="form-group">
                                 <label asp-for="IdTipoInscricao" class="control-label">Tipo de Inscrição</label>
                                 <select asp-for="IdTipoInscricao" class="form-control">
-                                    @if (Model?.TiposInscricaos is null)
+                                    @if (Model?.TiposInscricaos is null || !Model.TiposInscricaos.Any())
                                     {
                                     <option value="">Nenhum Disponível</option>
                                     }

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
@@ -54,7 +54,7 @@
                             <div class="form-group">
                                 <label asp-for="IdTipoInscricao" class="control-label">Tipo de Inscrição</label>
                                 <select asp-for="IdTipoInscricao" class="form-control">
-                                    @if (!Model.TiposInscricaos.Any())
+                                    @if (Model?.TiposInscricaos is null)
                                     {
                                     <option value="">Nenhum Disponível</option>
                                     }

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/Edit.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/Edit.cshtml
@@ -79,11 +79,11 @@
                                 <div class="d-flex align-items-center">
                                     <div class="form-check">
                                         <!-- Checkbox que marca se o evento ser� usado (valor 1) -->
-                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaEvento" name="TipoInscricao.UsadaEvento"
+                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaEvento" name="UsadaEvento"
                                         @(Model.UsadaEvento == 1 ? "checked" : "")>
                                         <label class="form-check-label" for="UsadaEvento">Usado em Evento</label>
                                         <!-- Campo oculto para enviar valor 0 quando o checkbox n�o est� marcado -->
-                                        <input type="hidden" name="TipoInscricao.UsadaEvento" value="0">
+                                        <input type="hidden" name="UsadaEvento" value="0">
                                     </div>
                                 </div>
                                 <span asp-validation-for="UsadaEvento" class="text-danger"></span>
@@ -94,11 +94,11 @@
                                 <div class="d-flex align-items-center">
                                     <div class="form-check">
                                         <!-- Checkbox que marca se o subevento ser� usado (valor 1) -->
-                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaSubevento" name="TipoInscricao.UsadaSubevento"
+                                        <input class="form-check-input" type="checkbox" value="1" id="UsadaSubevento" name="UsadaSubevento"
                                         @(Model.UsadaSubevento == 1 ? "checked" : "")>
                                         <label class="form-check-label" for="UsadaSubevento">Usado em Subevento</label>
                                         <!-- Campo oculto para enviar valor 0 quando o checkbox n�o est� marcado -->
-                                        <input type="hidden" name="TipoInscricao.UsadaSubevento" value="0">
+                                        <input type="hidden" name="UsadaSubevento" value="0">
                                     </div>
                                 </div>
                                 <span asp-validation-for="UsadaSubevento" class="text-danger"></span>

--- a/Codigo/Evento/Service/TipoInscricaoService.cs
+++ b/Codigo/Evento/Service/TipoInscricaoService.cs
@@ -139,7 +139,7 @@ namespace Service
                 tipoInscricao.UsadaSubevento = 1;
 
                 subevento.IdTipoInscricaos.Add(tipoInscricao);
-                _context.SaveChanges(); 
+                _context.SaveChanges();
             }
         }
 


### PR DESCRIPTION
Antes em adicionar tipo de inscrição a subeventos a lista ficava vazia mesmo que tivesse tipos de inscrição cadastrado ao evento.
Isso acontecia porque mesmo que marcasse usada por subevento, ficava como se o subevento não ussasse aquele tipo iscrição. 
Ainda sim adicionar tipo inscrição a subevento não está funcionando completamente, está dando como se o modelState fosse inválido, fica para resolver em outra PR.
#599 