### PR TITLE
Corriji adicionar tipo inscrição a subevento

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
@@ -175,6 +175,8 @@ namespace EventoWeb.Controllers
 
             var view = new TipoInscricaoSubeventoModel()
             {
+                NomeSubevento = subevento.Nome,
+                IdSubevento = idSubevento,
                 TiposInscricaos = new SelectList(tiposInscricaos, "Id", "Nome"),
                 TiposInscricaosSubevento = tiposInscricaosSubevento
             };
@@ -188,29 +190,52 @@ namespace EventoWeb.Controllers
         {
             if (!ModelState.IsValid)
             {
-                ModelState.AddModelError("", "Por favor, selecione um Tipo de Inscrição válido.");
+                ModelState.AddModelError("", "Por favor, preencha todos os campos obrigatórios.");
 
-                var subevento = _subeventoService.Get(model.IdSubevento);
-                var subeventoModel = _mapper.Map<SubeventoModel>(subevento);
-                var tiposInscricaos = _tipoInscricaoService.GetByEventoUsadaSubevento(subevento.IdEvento);
+                var subeventoM = _subeventoService.Get(model.IdSubevento);
+                var tiposInscricaos = _tipoInscricaoService.GetByEventoUsadaSubevento(subeventoM.IdEvento);
                 var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(model.IdSubevento);
 
-                ViewData["EventoId"] = subevento.IdEvento;
+                ViewData["EventoId"] = subeventoM.IdEvento;
 
                 var view = new TipoInscricaoSubeventoModel()
                 {
+                    NomeSubevento = subeventoM.Nome,
+                    IdSubevento = subeventoM.Id,
                     TiposInscricaos = new SelectList(tiposInscricaos, "Id", "Nome"),
                     TiposInscricaosSubevento = tiposInscricaosSubevento
                 };
                 return View(view);
             }
 
-            _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(model.IdSubevento, model.IdTipoInscricao);
-            return RedirectToAction("CreateTipoInscricaoSubevento", new { model.IdSubevento });
+            try
+            {
+                _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(model.IdSubevento, model.IdTipoInscricao);
+                return RedirectToAction("CreateTipoInscricaoSubevento", new { model.IdSubevento });
+            }
+            catch (ServiceException ex)
+            {
+                var subevento = _subeventoService.Get(model.IdSubevento);
+
+                ModelState.AddModelError("", ex.Message);
+                var tiposInscricaos = _tipoInscricaoService.GetByEventoUsadaSubevento(subevento.IdEvento);
+                var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(model.IdSubevento);
+                ViewData["EventoId"] = subevento.IdEvento;
+                var view = new TipoInscricaoSubeventoModel()
+                {
+                    NomeSubevento = subevento.Nome,
+                    IdSubevento = subevento.Id,
+                    TiposInscricaos = new SelectList(tiposInscricaos, "Id", "Nome"),
+                    TiposInscricaosSubevento = tiposInscricaosSubevento
+                };
+                return View(view);
+
+            }
+
         }
 
         // POST: /TipoInscricao/DeleteTipoInscricaoSubevento
-        [HttpPost("DeleteTipoInscricaoSubevento")] 
+        [HttpPost("DeleteTipoInscricaoSubevento")]
         [ValidateAntiForgeryToken]
         public IActionResult DeleteTipoInscricaoSubevento(uint idSubevento, uint IdTipoInscricao)
         {

--- a/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/TipoInscricaoController.cs
@@ -175,7 +175,6 @@ namespace EventoWeb.Controllers
 
             var view = new TipoInscricaoSubeventoModel()
             {
-                Subevento = subeventoModel,
                 TiposInscricaos = new SelectList(tiposInscricaos, "Id", "Nome"),
                 TiposInscricaosSubevento = tiposInscricaosSubevento
             };
@@ -191,24 +190,23 @@ namespace EventoWeb.Controllers
             {
                 ModelState.AddModelError("", "Por favor, selecione um Tipo de Inscrição válido.");
 
-                var subevento = _subeventoService.Get(model.Subevento.Id);
+                var subevento = _subeventoService.Get(model.IdSubevento);
                 var subeventoModel = _mapper.Map<SubeventoModel>(subevento);
                 var tiposInscricaos = _tipoInscricaoService.GetByEventoUsadaSubevento(subevento.IdEvento);
-                var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(model.Subevento.Id);
+                var tiposInscricaosSubevento = _tipoInscricaoService.GetTiposInscricaosSubevento(model.IdSubevento);
 
                 ViewData["EventoId"] = subevento.IdEvento;
 
                 var view = new TipoInscricaoSubeventoModel()
                 {
-                    Subevento = subeventoModel,
                     TiposInscricaos = new SelectList(tiposInscricaos, "Id", "Nome"),
                     TiposInscricaosSubevento = tiposInscricaosSubevento
                 };
                 return View(view);
             }
 
-            _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(model.Subevento.Id, model.IdTipoInscricao);
-            return RedirectToAction("CreateTipoInscricaoSubevento", new { model.Subevento.Id });
+            _tipoInscricaoService.AssociacaoTipoInscricaoSubevento(model.IdSubevento, model.IdTipoInscricao);
+            return RedirectToAction("CreateTipoInscricaoSubevento", new { model.IdSubevento });
         }
 
         // POST: /TipoInscricao/DeleteTipoInscricaoSubevento

--- a/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
@@ -6,8 +6,8 @@ namespace EventoWeb.Models;
 
 public class TipoInscricaoSubeventoModel
 {
-    public SubeventoModel Subevento { get; set; } = null!;
-    public SelectList TiposInscricaos { get; set; }
-    public IEnumerable<TipoInscricaoDTO> TiposInscricaosSubevento { get; set; }
+    public uint IdSubevento { get; set; }
+    public SelectList? TiposInscricaos { get; set; }
+    public IEnumerable<TipoInscricaoDTO>? TiposInscricaosSubevento { get; set; }
     public uint IdTipoInscricao { get; set; }
 }

--- a/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
@@ -1,13 +1,19 @@
 using Core;
 using Core.DTO;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.ComponentModel.DataAnnotations;
 
 namespace EventoWeb.Models;
 
 public class TipoInscricaoSubeventoModel
 {
     public uint IdSubevento { get; set; }
+    public string? NomeSubevento { get; set; }
+
     public SelectList? TiposInscricaos { get; set; }
     public IEnumerable<TipoInscricaoDTO>? TiposInscricaosSubevento { get; set; }
+
+    [Required(ErrorMessage = "É preciso selecionar um tipo de inscrição")]
     public uint IdTipoInscricao { get; set; }
+
 }

--- a/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/TipoInscricaoSubeventoModel.cs
@@ -13,7 +13,6 @@ public class TipoInscricaoSubeventoModel
     public SelectList? TiposInscricaos { get; set; }
     public IEnumerable<TipoInscricaoDTO>? TiposInscricaosSubevento { get; set; }
 
-    [Required(ErrorMessage = "É preciso selecionar um tipo de inscrição")]
     public uint IdTipoInscricao { get; set; }
 
 }

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
@@ -32,7 +32,7 @@
                                         }
                                         else
                                         {
-                                            <option value="@Model.IdSubevento" selected>@Model.IdSubevento</option>
+                                            <option value="@Model.NomeSubevento" selected>@Model.NomeSubevento</option>
                                         }
                                     </select>
                                 </div>

--- a/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/TipoInscricao/CreateTipoInscricaoSubevento.cshtml
@@ -24,15 +24,15 @@
                             <div class="col-3">
                                 <div class="form-group">
                                     <label for="IdSubevento" class="control-label">Subevento</label>
-                                    <input type="hidden" name="Subevento.Id" value="@Model?.Subevento?.Id" />
+                                    <input type="hidden" name="IdSubevento" value="@Model?.IdSubevento" />
                                     <select class="form-control" disabled>
-                                        @if (Model?.Subevento?.Id == null || Model.Subevento.Id == 0)
+                                        @if (Model?.IdSubevento == null || Model.IdSubevento == 0)
                                         {
                                             <option value="0">Não Informado</option>
                                         }
                                         else
                                         {
-                                            <option value="@Model.Subevento.Id" selected>@Model.Subevento.Nome</option>
+                                            <option value="@Model.IdSubevento" selected>@Model.IdSubevento</option>
                                         }
                                     </select>
                                 </div>
@@ -90,7 +90,7 @@
             <td style="vertical-align: middle;">@tipoInscricaoSubevento.Datafim.ToString("dd/MM/yyyy")</td>
             <td style="vertical-align: middle;">
                 <form asp-action="DeleteTipoInscricaoSubevento" method="post" style="display:inline;" onsubmit="return confirm('Tem certeza que deseja excluir?');">
-                    <input type="hidden" name="idSubevento" value="@Model.Subevento.Id" />
+                    <input type="hidden" name="idSubevento" value="@Model.IdSubevento" />
                     <input type="hidden" name="idTipoInscricao" value="@tipoInscricaoSubevento.Id" />
                     <button type="submit" class="btn btn-danger">Excluir</button>
                 </form>

--- a/Codigo/Evento/Service/TipoInscricaoService.cs
+++ b/Codigo/Evento/Service/TipoInscricaoService.cs
@@ -124,7 +124,7 @@ namespace Service
         /// </summary>
         public void AssociacaoTipoInscricaoSubevento(uint Idsubevento, uint IdtipoInscricao)
         {
-            var subevento = _context.Subeventos.FirstOrDefault(s => s.Id == Idsubevento);
+            var subevento = _context.Subeventos.Find(Idsubevento);
             if (subevento == null) throw new ServiceException("Subevento não encontrado.");
 
             _context.Entry(subevento).Collection(s => s.IdTipoInscricaos).Load();
@@ -136,10 +136,12 @@ namespace Service
 
             if (!subevento.IdTipoInscricaos.Any(ti => ti.Id == IdtipoInscricao))
             {
-                tipoInscricao.UsadaSubevento = 1;
-
                 subevento.IdTipoInscricaos.Add(tipoInscricao);
                 _context.SaveChanges();
+            }
+            else
+            {
+                throw new ServiceException("Tipo de Inscrição já associado ao subevento.");
             }
         }
 


### PR DESCRIPTION
Melhorei o formulário de tipo inscrição subevento com validação e tratamento de erros melhores:
- Adicionei o atributo NomeSubevento para exibição e validação no modelo
- Melhorei as mensagens de erro e o preenchimento do formulário quando a validação falha
- Adicionei um bloco try-catch para lidar com exceções do serviço ao associar o tipo de inscrição
- Alterei a view para mostrar o nome do subevento em vez do ID
- Adicionei verificação para evitar associações duplicadas de tipo de inscrição
- Otimizei a consulta ao banco usando Find em vez de FirstOrDefault

#609 