### PR TITLE
Melhorando validação da página

### DIFF
--- a/Codigo/Evento/EventoWeb/EventoWeb.csproj
+++ b/Codigo/Evento/EventoWeb/EventoWeb.csproj
@@ -7,18 +7,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="NovaPasta1\**" />
     <Compile Remove="NovaPasta\**" />
     <Compile Remove="wwwroot\lib\NovaPasta1\**" />
     <Compile Remove="wwwroot\lib\NovaPasta\**" />
     <Compile Remove="wwwroot\NovaPasta\**" />
+    <Content Remove="NovaPasta1\**" />
     <Content Remove="NovaPasta\**" />
     <Content Remove="wwwroot\lib\NovaPasta1\**" />
     <Content Remove="wwwroot\lib\NovaPasta\**" />
     <Content Remove="wwwroot\NovaPasta\**" />
+    <EmbeddedResource Remove="NovaPasta1\**" />
     <EmbeddedResource Remove="NovaPasta\**" />
     <EmbeddedResource Remove="wwwroot\lib\NovaPasta1\**" />
     <EmbeddedResource Remove="wwwroot\lib\NovaPasta\**" />
     <EmbeddedResource Remove="wwwroot\NovaPasta\**" />
+    <None Remove="NovaPasta1\**" />
     <None Remove="NovaPasta\**" />
     <None Remove="wwwroot\lib\NovaPasta1\**" />
     <None Remove="wwwroot\lib\NovaPasta\**" />
@@ -52,10 +56,6 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="NovaPasta1\" />
   </ItemGroup>
 
 </Project>

--- a/Codigo/Evento/EventoWeb/Models/GestaoAdministradorModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/GestaoAdministradorModel.cs
@@ -20,11 +20,12 @@ namespace EventoWeb.Models
         public string Cpf { get; set; } = null!;
 
         [Display(Name = "Telefone")]
-        [TelefoneCelular(ErrorMessage = "Digite um número válido")]
+        [TelefoneCelular(ErrorMessage = "Digite um telefone válido com DDD. Ex: (11) 91234-5678")]
         public string? Telefone1 { get; set; }
 
         [Display(Name = "E-mail")]
         [Required(ErrorMessage = "E-mail é obrigatório")]
+        [EmailAddress(ErrorMessage = "Por favor, digite um e-mail em um formato válido.")]
         public string Email { get; set; } = null!;
         public List<PessoaModel> Administradores { get; set; } = new List<PessoaModel>();
     }

--- a/Codigo/Evento/EventoWeb/Models/GestaoAdministradorModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/GestaoAdministradorModel.cs
@@ -16,7 +16,7 @@ namespace EventoWeb.Models
         [Required(ErrorMessage = "O campo CPF é obrigatório.")]
         [CPF(ErrorMessage = "CPF inválido")]
         [Display(Name = "CPF", Prompt = "Digite seu CPF")]
-        [StringLength(11, MinimumLength = 11, ErrorMessage = "O campo CPF deve ter 11 caracteres")]
+        [StringLength(11, MinimumLength = 11, ErrorMessage = "O campo CPF deve ter 11 números")]
         public string Cpf { get; set; } = null!;
 
         [Display(Name = "Telefone")]

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -10,14 +10,14 @@
 
 <div class="row">
 	<div>
-		<form asp-action="DefinirAdministrador" method="post">
+		<form asp-action="DefinirAdministrador" method="post" novalidate>
 			<div class="row">
 				<br />
 				<div class="row">
 					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
 						<div class="form-group mb-4">
 							<label asp-for="Cpf" class="control-label">CPF</label>
-							<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCPF()" maxlength="14" />
+							<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCPF(Cpf)" maxlength="14" />
 							<span asp-validation-for="Cpf" class="text-danger"></span>
 						</div>
 					</div>

--- a/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Pessoa/DefinirAdministrador.cshtml
@@ -10,14 +10,14 @@
 
 <div class="row">
 	<div>
-		<form asp-action="DefinirAdministrador" method="post" novalidate>
+		<form asp-action="DefinirAdministrador" onsubmit="removerMascara()" method="post" novalidate>
 			<div class="row">
 				<br />
 				<div class="row">
 					<div class="col-6 col-sm-6 col-md-6 col-lg-6">
 						<div class="form-group mb-4">
 							<label asp-for="Cpf" class="control-label">CPF</label>
-							<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCPF(Cpf)" maxlength="14" />
+							<input asp-for="Cpf" class="form-control" id="Cpf" placeholder="000.000.000-00" oninput="formatarCpfForm(Cpf)" maxlength="14" />
 							<span asp-validation-for="Cpf" class="text-danger"></span>
 						</div>
 					</div>

--- a/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Shared/_LayoutAdministrativo.cshtml
@@ -97,6 +97,7 @@
     <script src="~/js/time_message.js"></script>
     <script src="~/lib/datatable/js/datatables.min.js"></script>
     <script src="~/js/datatables.js"></script>
+    <script src="~/js/formatarCpfCadastro.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
  
 </body>

--- a/Codigo/Evento/EventoWeb/wwwroot/js/FormatarCpfCadastro.js
+++ b/Codigo/Evento/EventoWeb/wwwroot/js/FormatarCpfCadastro.js
@@ -1,0 +1,17 @@
+﻿function formatarCpfForm(campo) {
+
+    let cpf = campo.value.replace(/\D/g, "");
+    cpf = cpf.replace(/(\d{3})(\d)/, "$1.$2");
+    cpf = cpf.replace(/(\d{3})(\d)/, "$1.$2");
+    cpf = cpf.replace(/(\d{3})(\d{1,2})$/, "$1-$2");
+    campo.value = cpf;
+}
+
+function removerMascara() {
+    let cpf = document.getElementById("Cpf");
+    if (cpf) {
+        cpf.value = cpf.value.replace(".", "");
+        cpf.value = cpf.value.replace(".", "");
+        cpf.value = cpf.value.replace("-", "");
+    }
+}


### PR DESCRIPTION
Validação aprimorada de formulários do adm, com mensagens de erro mais claras para os campos de telefone e e-mail. Adicionei 'novalidate' para utilizar a própria lógica de validação e evitar a caixa de validação do navegador. Além disso, melhorei a mensagem de erro do telefone e adicionei ao modal de adm mensagens de erro caso o email seja digitado errado. #595 