### PR TITLE
Atualizar padrões, validação e visualização de subevento

### DIFF
--- a/Codigo/Evento/EventoWeb/Models/EventoModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/EventoModel.cs
@@ -26,7 +26,7 @@ namespace EventoWeb.Models
         [Display(Name = "Data Fim")]
         [DataType(DataType.Date)]
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = false)]
-		public DateTime? DataFim { get; set; } = DateTime.Today;
+		public DateTime? DataFim { get; set; } = DateTime.Today.AddDays(7);
 
 		[Display(Name = "Descrição")]
 		public string? Descricao { get; set; }
@@ -37,7 +37,6 @@ namespace EventoWeb.Models
 		[Display(Name = "Status")]
 		[Required(ErrorMessage = "Status do Evento é obrigatório")]
 		public string Status { get; set; } = null!;
-
 
 		[Required(ErrorMessage = "A data e hora inicial de inscrição são obrigatórias.")]
 		[DisplayFormat(DataFormatString = "{0:dd/MM/yyyy HH:mm}", ApplyFormatInEditMode = false)]

--- a/Codigo/Evento/EventoWeb/Models/SubeventoModel.cs
+++ b/Codigo/Evento/EventoWeb/Models/SubeventoModel.cs
@@ -1,6 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
-using Core.DTO;
+﻿using Core.DTO;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.ComponentModel.DataAnnotations;
+using Util;
 
 namespace EventoWeb.Models
 {
@@ -25,12 +26,15 @@ namespace EventoWeb.Models
         public string Descricao { get; set; } = null!;
 
         [Display(Name = "Data Inicial do Subvento")]
+        [DataType(DataType.Date)]
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = false)]
-        public DateTime DataInicio { get; set; }
+        [DataInicio(nameof(DataFim))]
+        public DateTime DataInicio { get; set; } = DateTime.Today;
 
         [Display(Name = "Data Final do Subvento")]
+        [DataType(DataType.Date)]
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = false)]
-        public DateTime DataFim { get; set; }
+        public DateTime DataFim { get; set; } = DateTime.Today.AddDays(7);
 
         [Display(Name = "Incrição gratuita")]
         public sbyte InscricaoGratuita { get; set; }
@@ -51,16 +55,20 @@ namespace EventoWeb.Models
         [Required(ErrorMessage = "Status do Subevento é obrigatório")]
         public string Status { get; set; } = null!;
 
+        [Required(ErrorMessage = "A data e hora inicial de inscrição são obrigatórias.")]
         [Display(Name = "Data Inicial de Inscrição")]
-        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = false)]
-        public DateTime DataInicioInscricao { get; set; }
+        [DataType(DataType.Date)]
+        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy HH:mm}", ApplyFormatInEditMode = false)]
+        [DataInicio(nameof(DataFim))]
+        public DateTime DataInicioInscricao { get; set; } = DateTime.Today;
 
+        [Required(ErrorMessage = "A data e hora final de inscrição são obrigatórias.")]
         [Display(Name = "Data Final de Inscrição")]
-        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = false)]
-        public DateTime DataFimInscricao { get; set; }
+        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy HH:mm}", ApplyFormatInEditMode = false)]
+        public DateTime DataFimInscricao { get; set; } = DateTime.Today.AddDays(7);
 
-        [Display(Name = "Valor da Inscrição", Prompt = "R$ 00.00")]
-        [Range(typeof(decimal), "0", "9999999999", ErrorMessage = "O valor deve ser zero ou maior que zero.")]
+        [Display(Name = "Menor Valor de Inscrição", Prompt = "R$ 00.00")]
+        [Range(typeof(decimal), "0.00", "999999", ErrorMessage = "O valor deve ser zero ou maior que zero.")]
         [RegularExpression(@"^\d+([.,]\d{1,2})?$", ErrorMessage = "Por favor, insira no máximo duas casas decimais, usando ',' ou '.' como separador decimal.")]
         public decimal ValorInscricao { get; set; }
 
@@ -68,6 +76,7 @@ namespace EventoWeb.Models
         public sbyte PossuiCertificado { get; set; }
 
         [Display(Name = "Frequência Minima")]
+        [Range(0.00, 100, ErrorMessage = "A frequencia minima deve ser entre 0 e 100.")]
         public decimal FrequenciaMinimaCertificado { get; set; }
 
         [Required]

--- a/Codigo/Evento/EventoWeb/Views/Subevento/CreateOrEdit.cshtml
+++ b/Codigo/Evento/EventoWeb/Views/Subevento/CreateOrEdit.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "CreateOrEdit";
 }
 
-<h1 class="blue-normal">Cadastro</h1>
+<h1 class="blue-normal">Cadastro de SubEventos</h1>
 <hr />
 <div class="row">
     <div>
@@ -139,7 +139,7 @@
                     <div class="form-group" id="FrequenciaMinimaCertificado">
                         <label asp-for="FrequenciaMinimaCertificado" class="control-label">Frequência mínima de emissão de certificado</label>
                         <div class="input-group" style="width:10rem;">
-                            <input asp-for="FrequenciaMinimaCertificado" class="form-control" style="border-right-style:none;" type="number" value="" step="0.01" min="0" max="100" />
+                            <input asp-for="FrequenciaMinimaCertificado" class="form-control" style="border-right-style:none;" type="number" value="" step="0.01" min="0" max="100" value="@Model.FrequenciaMinimaCertificado.ToString("F2", new System.Globalization.CultureInfo("pt-BR"))" placeholder="0,00"/>
                             <span class="input-group-text" style="background-color:white;">%</span>
                         </div>
                         <span asp-validation-for="FrequenciaMinimaCertificado" class="text-danger"></span>
@@ -182,7 +182,7 @@
             <div class="d-flex justify-content-end">
                 <div class="d-flex flex-row">
                     <div class="form-group" style="margin-right: 10px;">
-                        <input type="submit" value="Salvar" class="btn btn-blue-normal color-white" />
+                        <input type="submit" value="Salvar" class="btn btn-blue-normal color-white" value="@Model.ValorInscricao.ToString("F2", new System.Globalization.CultureInfo("pt-BR"))" placeholder="0,00" />
                     </div>
                     <div class="form-group">
                         <a asp-controller="Evento" asp-action="GerenciarEvento" asp-route-idEvento="@Model.IdEvento" class="btn btn-outline-danger">Voltar</a>


### PR DESCRIPTION
Definição de intervalos de datas padrão e melhoria na validação/formatação para subeventos. `EventoModel.DataFim` agora tem como padrão a data atual mais 7 dias. Em `SubeventoModel`: reorganização das diretivas `using`, adição de atributos `DataType` e `DisplayFormat`, validação de `DataInicio`, definição de datas de início/fim padrão, anotações de obrigatoriedade para datas de inscrição, restrição da faixa de valores e ajuste do rótulo de exibição para `ValorInscricao`, além da adição de uma validação de intervalo (`Range`) para `FrequenciaMinimaCertificado`. Ajustes de texto e layout na View (CreateOrEdit); atualização do campo de frequência e do botão de envio para exibir valores formatados de acordo com a cultura local e *placeholders*.