### PR TITLE
fix(view): Alterar tela de inicio de manter adm

### DIFF
--- a/Codigo/Evento/EventoWeb/Controllers/HomeController.cs
+++ b/Codigo/Evento/EventoWeb/Controllers/HomeController.cs
@@ -48,6 +48,11 @@ namespace EventoWeb.Controllers
                 }).ToList();
                 return View("IndexGestor", eventosGestorModel);
             }
+            
+            if(User.IsInRole("ADMINISTRADOR"))
+            {
+                return RedirectToAction("Index", "Evento");
+            }
             var listarEventos = _eventoService.GetAll().ToList();
             var listarEventosModel = _mapper.Map<List<EventoModel>>(listarEventos);
             return View(listarEventosModel);


### PR DESCRIPTION
Foi realizado uma pequena modificação no controller de home, assim que um administrador logar o mesmo deve ir para a tela index de eventos. Lembrando que a tela de eventos não está de acordo com o protótipo, mas no momento não é meu caso de uso e por isso não corrigi.#629